### PR TITLE
Upgrade to .NET 7

### DIFF
--- a/AudioTagger.Console/AudioTagger.Console.csproj
+++ b/AudioTagger.Console/AudioTagger.Console.csproj
@@ -15,12 +15,12 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="TagLibSharp" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
-    <PackageReference Include="Spectre.Console" Version="0.43.0" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
+    <PackageReference Include="Spectre.Console" Version="0.45.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AudioTagger.Library\AudioTagger.Library.csproj" />

--- a/AudioTagger.Console/AudioTagger.Console.csproj
+++ b/AudioTagger.Console/AudioTagger.Console.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
     <AssemblyName>Audiotagger.Console</AssemblyName>
   </PropertyGroup>

--- a/AudioTagger.Library/AudioTagger.Library.csproj
+++ b/AudioTagger.Library/AudioTagger.Library.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/AudioTagger.Library/AudioTagger.Library.csproj
+++ b/AudioTagger.Library/AudioTagger.Library.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="TagLibSharp" Version="2.2.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
-    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
+    <PackageReference Include="TagLibSharp" Version="2.3.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="7.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.0" />
+    <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="6.0.5.128" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Regexes.txt">

--- a/AudioTagger.Tests/AudioTagger.Tests.csproj
+++ b/AudioTagger.Tests/AudioTagger.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/AudioTagger.Tests/AudioTagger.Tests.csproj
+++ b/AudioTagger.Tests/AudioTagger.Tests.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Audiotagger
 
 - View file tags
-- Update file tags (automatically or manually)
-- Rename files
-- Reorganize files by their tag data
+- Update file tags using their filenames
+- Manually update specific tags (still half-done)
+- Rename files using their filenames
+- Reorganize files into folders using  their tag data
 - Find duplicate files by their tags
-- See stats
+- See folder stats
 
 This is a personal project that I work on in my spare time every now and then, so it's not very polished, but it is a bit of a labor of love.
 
-Written using the latest released versions of .NET and C#.
+Runs on .NET 7 and C# 11 as of November 2022.


### PR DESCRIPTION
It's November 2022, and .NET 7—including C# 11—is out. Time to upgrade!

- Upgrade to .NET 7 and C# 11
- Upgrade several NuGet packages (I received a GitHub security notice about vulnerabilities in the older versions I was using)