### PR TITLE
When renaming, keep single-track artists in root directory

### DIFF
--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -54,7 +54,7 @@ namespace AudioTagger.Console
                     if (isCancelRequested)
                         break;
 
-                    var useRootPath = artistCounts[string.Concat(file.Artists)] > 1;
+                    var useRootPath = artistCounts[string.Concat(file.Artists)] == 1;
 
                     isCancelRequested = RenameSingleFile(
                         file, printer, workingDirectory.FullName, useRootPath, ref doConfirm);
@@ -135,11 +135,19 @@ namespace AudioTagger.Console
                     ? new[] {titleText, yearText}
                     : new[] {albumText, yearText, " - ", trackText, titleText}) + ext;
 
-            var newFolderName = HasValue(file.AlbumArtists)
-                ? EnsurePathSafeString(string.Join(" && ", file.AlbumArtists))
-                : HasValue(file.Artists)
-                    ? EnsurePathSafeString(string.Join(" && ", file.Artists))
-                    : "_UNSPECIFIED";
+            string newFolderName;
+            if (keepInRootFolder)
+            {
+                newFolderName = string.Empty;
+            }
+            else
+            {
+                newFolderName = HasValue(file.AlbumArtists)
+                    ? EnsurePathSafeString(string.Join(" && ", file.AlbumArtists))
+                    : HasValue(file.Artists)
+                        ? EnsurePathSafeString(string.Join(" && ", file.Artists))
+                        : "_UNSPECIFIED-ARTIST";
+            }
             var fullFolderPath = Path.Combine(workingPath, newFolderName);
 
             var previousFolderFileName = file.Path.Replace(workingPath + Path.DirectorySeparatorChar, "");

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -49,6 +49,12 @@ namespace AudioTagger.Console
             {
                 var file = mediaFiles.ElementAt(i);
 
+                if (file.Title?.Length == 0)
+                {
+                    printer.Print($"Skipping \"{file.FileNameOnly}\" because it has no title.", fgColor: ConsoleColor.DarkRed);
+                    continue;
+                }
+
                 try
                 {
                     if (isCancelRequested)
@@ -107,10 +113,10 @@ namespace AudioTagger.Console
             const bool shouldCancel = false;
 
             //var albumArtistsText = string.Join(" & ", file.AlbumArtists) + " ≡ ";
-            var albumArtistText = HasValue(file.AlbumArtists)
+            var albumArtistText = HasAnyValues(file.AlbumArtists)
                 ? EnsurePathSafeString(string.Join(" && ", file.AlbumArtists)) + " ≡ "
                 : string.Empty;
-            var artistText = HasValue(file.Artists)
+            var artistText = HasAnyValues(file.Artists)
                 ? EnsurePathSafeString(string.Join(" && ", file.Artists)) + " - "
                 : string.Empty;
             var albumText = string.IsNullOrWhiteSpace(file.Album)
@@ -142,9 +148,9 @@ namespace AudioTagger.Console
             }
             else
             {
-                newFolderName = HasValue(file.AlbumArtists)
+                newFolderName = HasAnyValues(file.AlbumArtists)
                     ? EnsurePathSafeString(string.Join(" && ", file.AlbumArtists))
-                    : HasValue(file.Artists)
+                    : HasAnyValues(file.Artists)
                         ? EnsurePathSafeString(string.Join(" && ", file.Artists))
                         : "_UNSPECIFIED-ARTIST";
             }
@@ -234,7 +240,7 @@ namespace AudioTagger.Console
             /// <summary>
             /// Specifies whether the given collections has any valid values.
             /// </summary>
-            static bool HasValue(IEnumerable<string> tagValues)
+            static bool HasAnyValues(IEnumerable<string> tagValues)
             {
                 if (tagValues?.Any() != true)
                     return false;
@@ -276,7 +282,6 @@ namespace AudioTagger.Console
             {
                 if (!deletedDirectories.Any())
                 {
-                    printer.Print("No empty subdirectories were found.");
                     return;
                 }
 

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -165,8 +165,17 @@ namespace AudioTagger.Console
 
             var newPathFileName = Path.Combine(workingPath, newFolderName, newFileName);
 
-            printer.Print("   Current name: " + file.Path.Replace(workingPath, ""));
-            printer.Print("  Proposed name: " + Path.Combine(newFolderName, newPathFileName).Replace(workingPath, ""));
+            var currentFullPath = file.Path.Replace(workingPath, "");
+            var proposedFullPath = Path.Combine(newFolderName, newPathFileName).Replace(workingPath, "");
+
+            if (currentFullPath == proposedFullPath)
+            {
+                printer.Print($"No change needed for {currentFullPath}", fgColor: ConsoleColor.DarkGray);
+                return shouldCancel;
+            }
+
+            printer.Print("   Current name: " + currentFullPath);
+            printer.Print("  Proposed name: " + proposedFullPath, fgColor: ConsoleColor.Yellow);
 
             if (doConfirm)
             {


### PR DESCRIPTION
If an artist has multiple songs, a directory will be created for them. Otherwise, their song will reside in the top-level directory.