### PR TITLE
Show ReplayGain values

### DIFF
--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -35,7 +35,9 @@ public class MediaFileViewer
         var bitrate = file.BitRate.ToString();
         var sampleRate = file.SampleRate.ToString("#,##0");
         var trackReplayGain = file.ReplayGainTrack;
-        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | RG: {trackReplayGain}");
+        var albumReplayGain = double.IsNaN(file.ReplayGainAlbum) ? "--" : file.ReplayGainAlbum.ToString();
+        var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
+        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | {formattedReplayGainText}");
 
         if (file.Composers?.Length > 0)
         {

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -34,8 +34,8 @@ public class MediaFileViewer
 
         var bitrate = file.BitRate.ToString();
         var sampleRate = file.SampleRate.ToString("#,##0");
-        var hasReplayGain = file.HasReplayGainData ? "ReplayGain OK" : "No ReplayGain";
-        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | {hasReplayGain}");
+        var trackReplayGain = file.ReplayGainTrack;
+        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | RG: {trackReplayGain}");
 
         if (file.Composers?.Length > 0)
         {

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -34,10 +34,8 @@ public class MediaFileViewer
 
         var bitrate = file.BitRate.ToString();
         var sampleRate = file.SampleRate.ToString("#,##0");
-        var trackReplayGain = file.ReplayGainTrack;
-        var albumReplayGain = double.IsNaN(file.ReplayGainAlbum) ? "--" : file.ReplayGainAlbum.ToString();
-        var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
-        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | {formattedReplayGainText}");
+
+        table.AddRow(tagNameFormatter("Quality"), $"{bitrate} kbps @ {sampleRate} kHz | {file.ReplayGainSummary()}");
 
         if (file.Composers?.Length > 0)
         {

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -77,7 +77,8 @@ public class MediaFileViewer
             file.Title,
             file.Year == 0 ? string.Empty : file.Year.ToString(),
             string.Join(", ", file.Genres),
-            file.Duration.ToString("m\\:ss")
+            file.Duration.ToString("m\\:ss"),
+            file.ReplayGainTrack.ToString()
         };
 
         var markups = rows.Select(r => new Markup(r));

--- a/AudioTagger.Console/TagSummaryViewer.cs
+++ b/AudioTagger.Console/TagSummaryViewer.cs
@@ -18,7 +18,11 @@ public class TagSummaryViewer : IPathOperation
                                      .ThenBy(m => m.Title)
                                      .ToImmutableArray();
 
-        var table = PrepareTableWithColumns("Artist(s)", "Album", "Track", "Title", "Year", "Genre(s)", "Length");
+        var table = PrepareTableWithColumns("Artist(s)", "Album", "Trk", "Title", "Year", "Genre(s)", "Dur.", "RG(Tr.)");
+        table.Columns[2].Alignment(Justify.Right); // TODO: Combine with the name declarations above.
+        table.Columns[4].Alignment(Justify.Right);
+        table.Columns[6].Alignment(Justify.Right);
+        table.Columns[7].Alignment(Justify.Right);
 
         table = AppendDataRowsToTable(table,
                                       new MediaFileViewer(),

--- a/AudioTagger.Console/TagSummaryViewer.cs
+++ b/AudioTagger.Console/TagSummaryViewer.cs
@@ -18,11 +18,15 @@ public class TagSummaryViewer : IPathOperation
                                      .ThenBy(m => m.Title)
                                      .ToImmutableArray();
 
-        var table = PrepareTableWithColumns("Artist(s)", "Album", "Trk", "Title", "Year", "Genre(s)", "Dur.", "RG(Tr.)");
-        table.Columns[2].Alignment(Justify.Right); // TODO: Combine with the name declarations above.
-        table.Columns[4].Alignment(Justify.Right);
-        table.Columns[6].Alignment(Justify.Right);
-        table.Columns[7].Alignment(Justify.Right);
+        var table = CreateTableWithColumns(
+            ("Artist(s)", Justify.Left),
+            ("Album", Justify.Left),
+            ("Trk", Justify.Right),
+            ("Title", Justify.Left),
+            ("Year", Justify.Right),
+            ("Genre(s)", Justify.Left),
+            ("Dur.", Justify.Right),
+            ("RG(Tr)", Justify.Right));
 
         table = AppendDataRowsToTable(table,
                                       new MediaFileViewer(),
@@ -32,7 +36,7 @@ public class TagSummaryViewer : IPathOperation
         AnsiConsole.Write(table);
     }
 
-    private static Table PrepareTableWithColumns(params string[] columns)
+    private static Table CreateTableWithColumns(params (string, Justify)[] columnPairs)
     {
         var table = new Table
         {
@@ -40,7 +44,22 @@ public class TagSummaryViewer : IPathOperation
             Expand = true
         };
 
-        table.AddColumns(columns);
+        foreach (var pair in columnPairs)
+        {
+            var column = new TableColumn(pair.Item1);
+
+            switch (pair.Item2)
+            {
+                case Justify.Center:
+                    column = column.Centered();
+                    break;
+                case Justify.Right:
+                    column = column.RightAligned();
+                    break;
+            }
+
+            table.AddColumn(column);
+        }
 
         return table;
     }

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -14,10 +14,7 @@
             _taggedFile = tabLibFile;
         }
 
-        public string FileNameOnly
-        {
-            get => System.IO.Path.GetFileName(Path);
-        }
+        public string FileNameOnly => System.IO.Path.GetFileName(Path);
 
         public string Title
         {
@@ -89,7 +86,7 @@
             get => _taggedFile.Tag.Composers?.Select(c => c?.Trim()?.Normalize()
                                                           ?? string.Empty)?
                                              .ToArray()
-                    ?? Array.Empty<string>();
+                   ?? Array.Empty<string>();
 
             set => _taggedFile.Tag.Composers = value?.Select(g => g?.Trim()?
                                                                     .Normalize())?
@@ -115,19 +112,24 @@
             set => _taggedFile.Tag.Description = value.Trim().Normalize();
         }
 
-        public int BitRate
-        {
-            get => _taggedFile.Properties.AudioBitrate;
-        }
+        public int BitRate => _taggedFile.Properties.AudioBitrate;
 
-        public int SampleRate
-        {
-            get => _taggedFile.Properties.AudioSampleRate;
-        }
+        public int SampleRate => _taggedFile.Properties.AudioSampleRate;
 
         public double ReplayGainTrack => _taggedFile.Tag.ReplayGainTrackGain;
 
         public double ReplayGainAlbum => _taggedFile.Tag.ReplayGainAlbumGain;
+
+        /// <summary>
+        /// Gets text summary of track and album ReplayGain data.
+        /// </summary>
+        public string ReplayGainSummary()
+        {
+            const string noData = "———";
+            var trackGain = double.IsNaN(ReplayGainTrack) ? noData : ReplayGainTrack.ToString();
+            var albumGain = double.IsNaN(ReplayGainAlbum) ? noData : ReplayGainAlbum.ToString();
+            return $"Track: {trackGain} | Album: {albumGain}";
+        }
 
         // The embedded image for the album, represented as an array of bytes or,
         // if none, an empty array.
@@ -145,7 +147,7 @@
         }
 
         /// <summary>
-        /// Save updated tag data to the file.
+        /// Save pending tag data updates to the file.
         /// </summary>
         public void SaveUpdates()
         {
@@ -158,7 +160,7 @@
         /// and a path to a folder will return an AudioFile for each file within that folder.
         /// </summary>
         /// <param name="path">A directory or file path</param>
-        /// <returns>A collection of MediaFile</returns>
+        /// <returns>A collection of MediaFile.</returns>
         public static IReadOnlyCollection<MediaFile> PopulateFileData(string path, bool searchSubDirectories = false)
         {
             // If the path is a directory
@@ -180,10 +182,7 @@
                     {
                         mediaFiles.Add(MediaFileFactory.CreateFileData(fileName));
                     }
-                    catch (Exception)
-                    {
-
-                    }
+                    catch (Exception) { }
                 }
 
                 return mediaFiles.OrderBy(f => f.Path)

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -125,10 +125,9 @@
             get => _taggedFile.Properties.AudioSampleRate;
         }
 
-        public double ReplayGainTrack
-        {
-            get => _taggedFile.Tag.ReplayGainTrackGain;
-        }
+        public double ReplayGainTrack => _taggedFile.Tag.ReplayGainTrackGain;
+
+        public double ReplayGainAlbum => _taggedFile.Tag.ReplayGainAlbumGain;
 
         // The embedded image for the album, represented as an array of bytes or,
         // if none, an empty array.

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -125,11 +125,9 @@
             get => _taggedFile.Properties.AudioSampleRate;
         }
 
-        // TODO: Verify this is working correctly.
-        public bool HasReplayGainData
+        public double ReplayGainTrack
         {
-            get => _taggedFile.Tag.ReplayGainTrackGain != 0 ||
-                   _taggedFile.Tag.ReplayGainAlbumGain != 0;
+            get => _taggedFile.Tag.ReplayGainTrackGain;
         }
 
         // The embedded image for the album, represented as an array of bytes or,

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -128,7 +128,7 @@
             const string noData = "———";
             var trackGain = double.IsNaN(ReplayGainTrack) ? noData : ReplayGainTrack.ToString();
             var albumGain = double.IsNaN(ReplayGainAlbum) ? noData : ReplayGainAlbum.ToString();
-            return $"Track: {trackGain} | Album: {albumGain}";
+            return $"Track: {trackGain}  |  Album: {albumGain}";
         }
 
         // The embedded image for the album, represented as an array of bytes or,

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -89,7 +89,9 @@ namespace AudioTagger
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var trackReplayGain = fileData.ReplayGainTrack.ToString();
+            var trackReplayGain = fileData.ReplayGainTrack;
+            var albumReplayGain = double.IsNaN(fileData.ReplayGainAlbum) ? "--" : fileData.ReplayGainAlbum.ToString();
+            var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
 
             // Create formatted quality line
             const string genreSeparator = "    ";
@@ -102,7 +104,7 @@ namespace AudioTagger
                         new LineSubString(" kbps" + genreSeparator, ConsoleColor.DarkGray),
                         new LineSubString(sampleRate),
                         new LineSubString(" kHz" + genreSeparator, ConsoleColor.DarkGray),
-                        new LineSubString("RG: " + trackReplayGain)
+                        new LineSubString(formattedReplayGainText)
                     }));
 
             if (fileData.Composers?.Length > 0)
@@ -130,13 +132,15 @@ namespace AudioTagger
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var trackReplayGain = fileData.ReplayGainTrack.ToString();
+            var trackReplayGain = fileData.ReplayGainTrack;
+            var albumReplayGain = double.IsNaN(fileData.ReplayGainAlbum) ? "--" : fileData.ReplayGainAlbum.ToString();
+            var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
 
             // Create formatted quality line
             const string separator = "  |  ";
             lines.Add(
                 "Quality",
-                $"{bitrate}kbps" + separator + $"{sampleRate} kHz" + separator + "RG: " + trackReplayGain);
+                $"{bitrate}kbps" + separator + $"{sampleRate} kHz" + separator + formattedReplayGainText);
 
             if (fileData.Composers?.Length > 0)
                 lines.Add($"Composers", string.Join("; ", fileData.Composers));

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -89,9 +89,6 @@ namespace AudioTagger
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var trackReplayGain = fileData.ReplayGainTrack;
-            var albumReplayGain = double.IsNaN(fileData.ReplayGainAlbum) ? "--" : fileData.ReplayGainAlbum.ToString();
-            var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
 
             // Create formatted quality line
             const string genreSeparator = "    ";
@@ -104,7 +101,7 @@ namespace AudioTagger
                         new LineSubString(" kbps" + genreSeparator, ConsoleColor.DarkGray),
                         new LineSubString(sampleRate),
                         new LineSubString(" kHz" + genreSeparator, ConsoleColor.DarkGray),
-                        new LineSubString(formattedReplayGainText)
+                        new LineSubString(fileData.ReplayGainSummary())
                     }));
 
             if (fileData.Composers?.Length > 0)
@@ -118,13 +115,14 @@ namespace AudioTagger
 
         public static Dictionary<string, string> GetTagKeyValuePairs(MediaFile fileData)
         {
-            var lines = new Dictionary<string, string>();
-
-            lines.Add("Title", fileData.Title);
-            lines.Add("Artist(s)", string.Join(", ", fileData.Artists));
-            lines.Add("Album", fileData.Album);
-            lines.Add("Year", fileData.Year.ToString());
-            lines.Add("Duration", fileData.Duration.ToString("m\\:ss"));
+            var lines = new Dictionary<string, string>
+            {
+                { "Title", fileData.Title },
+                { "Artist(s)", string.Join(", ", fileData.Artists) },
+                { "Album", fileData.Album },
+                { "Year", fileData.Year.ToString() },
+                { "Duration", fileData.Duration.ToString("m\\:ss") }
+            };
 
             var genreCount = fileData.Genres.Length;
             lines.Add("Genre(s)", string.Join(", ", fileData.Genres) +
@@ -132,18 +130,15 @@ namespace AudioTagger
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var trackReplayGain = fileData.ReplayGainTrack;
-            var albumReplayGain = double.IsNaN(fileData.ReplayGainAlbum) ? "--" : fileData.ReplayGainAlbum.ToString();
-            var formattedReplayGainText = $"ReplayGain: T{trackReplayGain} A{albumReplayGain}";
 
             // Create formatted quality line
             const string separator = "  |  ";
             lines.Add(
                 "Quality",
-                $"{bitrate}kbps" + separator + $"{sampleRate} kHz" + separator + formattedReplayGainText);
+                $"{bitrate}kbps" + separator + $"{sampleRate} kHz" + separator + fileData.ReplayGainSummary());
 
             if (fileData.Composers?.Length > 0)
-                lines.Add($"Composers", string.Join("; ", fileData.Composers));
+                lines.Add("Composers", string.Join("; ", fileData.Composers));
 
             if (!string.IsNullOrWhiteSpace(fileData.Comments))
                 lines.Add("Comment", fileData.Comments);

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -74,21 +74,22 @@ namespace AudioTagger
 
         public static IList<OutputLine> GetTagPrintedLines(MediaFile fileData)
         {
-            var lines = new List<OutputLine>();
-
-            lines.Add(TagDataWithHeader("Title", fileData.Title));
-            lines.Add(TagDataWithHeader("Artist(s)", string.Join(", ", fileData.Artists)));
-            lines.Add(TagDataWithHeader("Album", fileData.Album));
-            lines.Add(TagDataWithHeader("Year", fileData.Year.ToString()));
-            lines.Add(TagDataWithHeader("Duration", fileData.Duration.ToString("m\\:ss")));
+            var lines = new List<OutputLine>
+            {
+                TagDataWithHeader("Title", fileData.Title),
+                TagDataWithHeader("Artist(s)", string.Join(", ", fileData.Artists)),
+                TagDataWithHeader("Album", fileData.Album),
+                TagDataWithHeader("Year", fileData.Year.ToString()),
+                TagDataWithHeader("Duration", fileData.Duration.ToString("m\\:ss"))
+            };
 
             var genreCount = fileData.Genres.Length;
             lines.Add(TagDataWithHeader("Genre(s)", string.Join(", ", fileData.Genres) +
-                                                (genreCount > 1 ? $" ({genreCount})" : "")));
+                                                    (genreCount > 1 ? $" ({genreCount})" : "")));
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var hasReplayGain = fileData.HasReplayGainData ? "ReplayGain OK" : "No ReplayGain";
+            var trackReplayGain = fileData.ReplayGainTrack.ToString();
 
             // Create formatted quality line
             const string genreSeparator = "    ";
@@ -101,7 +102,7 @@ namespace AudioTagger
                         new LineSubString(" kbps" + genreSeparator, ConsoleColor.DarkGray),
                         new LineSubString(sampleRate),
                         new LineSubString(" kHz" + genreSeparator, ConsoleColor.DarkGray),
-                        new LineSubString(hasReplayGain)
+                        new LineSubString("RG: " + trackReplayGain)
                     }));
 
             if (fileData.Composers?.Length > 0)
@@ -129,13 +130,13 @@ namespace AudioTagger
 
             var bitrate = fileData.BitRate.ToString();
             var sampleRate = fileData.SampleRate.ToString("#,##0");
-            var hasReplayGain = fileData.HasReplayGainData ? "ReplayGain OK" : "No ReplayGain";
+            var trackReplayGain = fileData.ReplayGainTrack.ToString();
 
             // Create formatted quality line
-            const string genreSeparator = "  |  ";
+            const string separator = "  |  ";
             lines.Add(
                 "Quality",
-                $"{bitrate}kbps" + genreSeparator + $"{sampleRate} kHz" + genreSeparator + hasReplayGain);
+                $"{bitrate}kbps" + separator + $"{sampleRate} kHz" + separator + "RG: " + trackReplayGain);
 
             if (fileData.Composers?.Length > 0)
                 lines.Add($"Composers", string.Join("; ", fileData.Composers));


### PR DESCRIPTION
Until now, the ReplayGain option has only showed whether the file has any ReplayGain data within in. Now, the actual value(s) will be shown. (Currently, this only includes track data, but I might add album data too.)