### PR TITLE
Escape tag data when printing to tables

### DIFF
--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -130,7 +130,7 @@ namespace AudioTagger.Console
             };
         }
 
-        public void PrintTagDataToTable(MediaFile mediaFile, IDictionary<string, string>? proposedUpdates)
+        public void PrintTagDataToTable(MediaFile mediaFile, IDictionary<string, string> proposedUpdates)
         {
             ArgumentNullException.ThrowIfNull(proposedUpdates);
 
@@ -142,18 +142,18 @@ namespace AudioTagger.Console
             tagTable.Border(TableBorder.None);
             tagTable.AddColumns("Tag Name", "Tag Value"); // Hidden on the next line, though.
             tagTable.ShowHeaders = false;
-            var tagLines = OutputLine.GetTagKeyValuePairs(mediaFile);
-            foreach (var line in tagLines)
-            {
-                tagTable.AddRow(line.Key, line.Value);
-            }
-            table.AddRow(tagTable);
 
+            foreach (var line in OutputLine.GetTagKeyValuePairs(mediaFile))
+            {
+                tagTable.AddRow(line.Key, line.Value.EscapeMarkup());
+            }
+
+            table.AddRow(tagTable);
             tagTable.AddEmptyRow();
 
             foreach (var update in proposedUpdates)
             {
-                tagTable.AddRow($"[olive]{update.Key}[/]", $"[yellow]{update.Value}[/]");
+                tagTable.AddRow($"[olive]{update.Key}[/]", $"[yellow]{update.Value.EscapeMarkup()}[/]");
             }
 
             AnsiConsole.Write(table);

--- a/AudioTagger.Library/IPrinter.cs
+++ b/AudioTagger.Library/IPrinter.cs
@@ -15,8 +15,7 @@
 
         char GetResultSymbol(ResultType type);
 
-        // void PrintTagDataToTable(MediaFile mediaFile, IDictionary<string, string>? proposedUpdates);
-        void PrintTagDataToTable(MediaFile mediaFile, IDictionary<string, string>? proposedUpdates);
+        void PrintTagDataToTable(MediaFile mediaFile, IDictionary<string, string> proposedUpdates);
 
         void PrintException(Exception ex);
     }


### PR DESCRIPTION
When tags contain data within square brackets ("[like this]"), Spectre.Console will try to parse them as formatting commands, leading to crashes.

Using the `EscapeMarkup()` method within Spectre.Console tables fixes this.