### PR TITLE
Add album artists to view summary

### DIFF
--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -74,7 +74,7 @@ public class MediaFileViewer
 
         var rows = new List<string>
         {
-            string.Join(", ", file.Artists).EscapeMarkup(),
+            GetCombinedArtists(file.AlbumArtists, file.Artists),
             file.Album.EscapeMarkup(),
             file.TrackNo == 0 ? string.Empty : file.TrackNo.ToString().EscapeMarkup(),
             file.Title.EscapeMarkup(),
@@ -87,5 +87,19 @@ public class MediaFileViewer
         var markups = rows.Select(r => new Markup(r));
 
         return new TableRow(markups);
+
+        static string GetCombinedArtists(string[] albumArtists, string[] artists)
+        {
+            var artistString = string.Join(", ", artists).EscapeMarkup();
+
+            if (!albumArtists.Any())
+                return artistString;
+
+            var albumArtistString = string.Join(", ", albumArtists).EscapeMarkup();
+
+            return albumArtistString == artistString
+                ? artistString
+                : $"{albumArtistString} ({artistString})";
+        }
     }
 }

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -14,7 +14,7 @@ internal static class OperationLibrary
         new(
             new List<string>{"-vs", "--view-summary"},
             "View a tag data summary.",
-            new TagSummaryViewer()
+            new TagViewerSummary()
         ),
         new(
             new List<string>{"-u", "--update"},

--- a/AudioTagger.Console/TagViewerSummary.cs
+++ b/AudioTagger.Console/TagViewerSummary.cs
@@ -2,7 +2,7 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class TagSummaryViewer : IPathOperation
+public class TagViewerSummary : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,


### PR DESCRIPTION
Album artists are currently ignored in the view summary (`-vs`). This adds them when they are present.