### PR TITLE
Automatic genre addition

### DIFF
--- a/AudioTagger.Console/GenreExtractor.cs
+++ b/AudioTagger.Console/GenreExtractor.cs
@@ -18,7 +18,7 @@ public sealed class GenreExtractor : IPathOperation
 
         var artistsWithGenres = mediaFiles
             .Where(f => f.Genres.Any() && f.Artists.Any())
-            .GroupBy(f => f.Artists[0], f => f.Genres)
+            .GroupBy(f => f.ArtistsCombined, f => f.Genres)
             .ToImmutableSortedDictionary(
                 f => f.Key,
                 f => f.First() // TODO: Get their most populous genre
@@ -32,7 +32,9 @@ public sealed class GenreExtractor : IPathOperation
             settings.ArtistGenres[pair.Key] = pair.Value[0];
         }
 
-        SettingsService.WriteSettingsToFile(settings, printer);
-        printer.Print("Wrote to the settings file!");
+        if (SettingsService.WriteSettingsToFile(settings, printer))
+            printer.Print("Saved artists and genres to the settings file.");
+        else
+            printer.Print("An error occurred during the process.");
     }
 }

--- a/AudioTagger.Console/GenreExtractor.cs
+++ b/AudioTagger.Console/GenreExtractor.cs
@@ -18,7 +18,7 @@ public sealed class GenreExtractor : IPathOperation
 
         var artistsWithGenres = mediaFiles
             .Where(f => f.Genres.Any() && f.Artists.Any())
-            .GroupBy(f => f.ArtistsCombined, f => f.Genres)
+            .GroupBy(f => f.Artists.Join(), f => f.Genres)
             .ToImmutableSortedDictionary(
                 f => f.Key,
                 f => f.First() // TODO: Get their most populous genre

--- a/AudioTagger.Console/GenreExtractor.cs
+++ b/AudioTagger.Console/GenreExtractor.cs
@@ -1,7 +1,3 @@
-using System.Text;
-using System.Text.RegularExpressions;
-using Spectre.Console;
-
 namespace AudioTagger.Console;
 
 public sealed class GenreExtractor : IPathOperation
@@ -9,10 +5,10 @@ public sealed class GenreExtractor : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings? settings = null) // # TODO: No need for nullability
     {
         if (settings is null)
-            throw new InvalidOperationException("Settings cannot be null");
+            throw new InvalidOperationException("Settings cannot be null.");
 
         if (!mediaFiles.Any())
         {
@@ -23,12 +19,12 @@ public sealed class GenreExtractor : IPathOperation
         var artistsWithGenres = mediaFiles
             .Where(f => f.Genres.Any() && f.Artists.Any())
             .GroupBy(f => f.Artists[0], f => f.Genres)
-            .ToImmutableDictionary(
+            .ToImmutableSortedDictionary(
                 f => f.Key,
                 f => f.First() // TODO: Get their most populous genre
             );
 
-        printer.Print($"Found {artistsWithGenres.Count} artists with genres.");
+        printer.Print($"Found {artistsWithGenres.Count:#,##0} artists with genres.");
 
         settings.ArtistGenres ??= new();
         foreach (var pair in artistsWithGenres)
@@ -36,7 +32,7 @@ public sealed class GenreExtractor : IPathOperation
             settings.ArtistGenres[pair.Key] = pair.Value[0];
         }
 
-        SettingsService.WriteSettingsFile(settings);
+        SettingsService.WriteSettingsToFile(settings, printer);
         printer.Print("Wrote to the settings file!");
     }
 }

--- a/AudioTagger.Console/GenreExtractor.cs
+++ b/AudioTagger.Console/GenreExtractor.cs
@@ -1,0 +1,42 @@
+using System.Text;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace AudioTagger.Console;
+
+public sealed class GenreExtractor : IPathOperation
+{
+    public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
+                      DirectoryInfo workingDirectory,
+                      IPrinter printer,
+                      Settings? settings = null)
+    {
+        if (settings is null)
+            throw new InvalidOperationException("Settings cannot be null");
+
+        if (!mediaFiles.Any())
+        {
+            printer.Print("There are no files to work on. Cancelling...");
+            return;
+        }
+
+        var artistsWithGenres = mediaFiles
+            .Where(f => f.Genres.Any() && f.Artists.Any())
+            .GroupBy(f => f.Artists[0], f => f.Genres)
+            .ToImmutableDictionary(
+                f => f.Key,
+                f => f.First() // TODO: Get their most populous genre
+            );
+
+        printer.Print($"Found {artistsWithGenres.Count} artists with genres.");
+
+        settings.ArtistGenres ??= new();
+        foreach (var pair in artistsWithGenres)
+        {
+            settings.ArtistGenres[pair.Key] = pair.Value[0];
+        }
+
+        SettingsService.WriteSettingsFile(settings);
+        printer.Print("Wrote to the settings file!");
+    }
+}

--- a/AudioTagger.Console/GenreExtractor.cs
+++ b/AudioTagger.Console/GenreExtractor.cs
@@ -5,11 +5,8 @@ public sealed class GenreExtractor : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null) // # TODO: No need for nullability
+                      Settings settings)
     {
-        if (settings is null)
-            throw new InvalidOperationException("Settings cannot be null.");
-
         if (!mediaFiles.Any())
         {
             printer.Print("There are no files to work on. Cancelling...");
@@ -20,7 +17,7 @@ public sealed class GenreExtractor : IPathOperation
             .Where(f => f.Genres.Any() && f.Artists.Any())
             .GroupBy(f =>
                 f.Artists[0], // Would be nice to split them
-                f => f.Genres.GroupBy(g => g)
+                f => f.Genres.GroupBy(g => g) // Get most populous
                              .OrderByDescending(grp => grp.Count())
                              .Select(grp=>grp.Key)
                              .First())

--- a/AudioTagger.Console/GetUserInput.cs
+++ b/AudioTagger.Console/GetUserInput.cs
@@ -12,7 +12,7 @@ public enum UserResponse
     Cancel
 }
 
-public record KeyResponse
+public sealed record KeyResponse
 {
     public char Key { get; init; }
     public UserResponse Response { get; init; }

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -71,7 +71,7 @@ public sealed class MediaFileRenamer : IPathOperation
                 if (isCancelRequested)
                     break;
 
-                var useRootPath = artistCounts[GetConcatenatedArtists(file)] == 1;
+                var useRootPath = artistCounts[file.AlbumArtists.JoinWith(file.Artists)] == 1;
 
                 isCancelRequested = RenameSingleFile(
                     file, printer, workingDirectory.FullName, useRootPath, ref doConfirm, renamePatterns);
@@ -105,7 +105,8 @@ public sealed class MediaFileRenamer : IPathOperation
 
         static IDictionary<string, int> GetArtistCounts(IReadOnlyCollection<MediaFile> mediaFiles)
         {
-            return mediaFiles.GroupBy(n => GetConcatenatedArtists(n))
+            return mediaFiles
+                .GroupBy(file => file.AlbumArtists.JoinWith(file.Artists))
                 .ToDictionary(g => g.Key, g => g.Count());
         }
     }
@@ -308,18 +309,5 @@ public sealed class MediaFileRenamer : IPathOperation
             foreach (var dir in deletedDirectories)
                 printer.Print("- " + dir);
         }
-    }
-
-    /// <summary>
-    /// Reads the album artists, if any, or else the artists of a file
-    /// and returns them in an unformatted, concatenated string.
-    /// </summary>
-    private static string GetConcatenatedArtists(MediaFile file)
-    {
-        // TODO: What if both fields are empty?
-        return string.Concat(
-            file.AlbumArtists.Any()
-                ? file.AlbumArtists
-                : file.Artists);
     }
 }

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -11,7 +11,7 @@ public sealed class MediaFileRenamer : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         if (!ConfirmContinue(workingDirectory, printer))
         {

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -76,17 +76,17 @@ public sealed class MediaFileRenamer : IPathOperation
                 isCancelRequested = RenameSingleFile(
                     file, printer, workingDirectory.FullName, useRootPath, ref doConfirm, renamePatterns);
             }
-            catch (IOException e)
+            catch (IOException ex)
             {
-                printer.Error($"Error updating \"{file.FileNameOnly}\": {e.Message}");
-                printer.PrintException(e);
-                errors.Add(e.Message); // The message should contain the file name.
+                printer.Error($"Error updating \"{file.FileNameOnly}\": {ex.Message}");
+                printer.PrintException(ex);
+                errors.Add(ex.Message); // The message should contain the file name.
             }
-            catch (KeyNotFoundException e)
+            catch (KeyNotFoundException ex)
             {
-                printer.Error($"Error updating \"{file.FileNameOnly}\": {e.Message}");
-                printer.PrintException(e);
-                errors.Add(e.Message);
+                printer.Error($"Error updating \"{file.FileNameOnly}\": {ex.Message}");
+                printer.PrintException(ex);
+                errors.Add(ex.Message);
             }
         }
 

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -19,9 +19,9 @@ public class MediaFileViewer
         if (file.AlbumArtists.Any())
         {
             table.AddRow(tagNameFormatter("Album Artist"),
-                         file.AlbumArtistsCombined.EscapeMarkup());
+                         file.AlbumArtists.Join().EscapeMarkup());
         }
-        table.AddRow(tagNameFormatter("Artist"), file.ArtistsCombined.EscapeMarkup());
+        table.AddRow(tagNameFormatter("Artist"), file.Artists.Join().EscapeMarkup());
         table.AddRow(tagNameFormatter("Album"), file.Album.EscapeMarkup());
         if (file.TrackNo > 0)
             table.AddRow(tagNameFormatter("Track"), file.TrackNo.ToString());
@@ -31,7 +31,7 @@ public class MediaFileViewer
 
         var genreCount = file.Genres.Length;
         table.AddRow(tagNameFormatter("Genres"),
-                     file.GenresCombined.EscapeMarkup() +
+                     file.Genres.Join().EscapeMarkup() +
                         (genreCount > 1 ? $" ({genreCount})" : ""));
 
         var bitrate = file.BitRate.ToString();
@@ -43,7 +43,7 @@ public class MediaFileViewer
         {
             table.AddRow(
                 tagNameFormatter("Composers"),
-                file.ComposersCombined.EscapeMarkup());
+                file.Composers.Join().EscapeMarkup());
         }
 
         if (!string.IsNullOrWhiteSpace(file.Comments))
@@ -71,12 +71,12 @@ public class MediaFileViewer
     {
         var rows = new List<string>
         {
-            file.AlbumArtistsAndArtistsCombined.EscapeMarkup(),
+            file.AlbumArtists.JoinWith(file.Artists).EscapeMarkup(),
             file.Album.EscapeMarkup(),
             file.TrackNo == 0 ? string.Empty : file.TrackNo.ToString().EscapeMarkup(),
             file.Title.EscapeMarkup(),
             file.Year == 0 ? string.Empty : file.Year.ToString(),
-            file.GenresCombined.EscapeMarkup(),
+            file.Genres.Join().EscapeMarkup(),
             file.Duration.ToString("m\\:ss"),
             file.ReplayGainTrack.ToString()
         };

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -21,9 +21,9 @@ public class MediaFileViewer
         if (file.AlbumArtists.Any())
         {
             table.AddRow(tagNameFormatter("Album Artist"),
-                         string.Join(", ", file.AlbumArtists).EscapeMarkup());
+                         file.AlbumArtistsCombined.EscapeMarkup());
         }
-        table.AddRow(tagNameFormatter("Artist"), string.Join(", ", file.Artists).EscapeMarkup());
+        table.AddRow(tagNameFormatter("Artist"), file.ArtistsCombined.EscapeMarkup());
         table.AddRow(tagNameFormatter("Album"), file.Album.EscapeMarkup());
         if (file.TrackNo > 0)
             table.AddRow(tagNameFormatter("Track"), file.TrackNo.ToString());
@@ -32,8 +32,9 @@ public class MediaFileViewer
         table.AddRow(tagNameFormatter("Duration"), file.Duration.ToString("m\\:ss"));
 
         var genreCount = file.Genres.Length;
-        table.AddRow(tagNameFormatter("Genres"), string.Join(", ", file.Genres).EscapeMarkup() +
-                                 (genreCount > 1 ? $" ({genreCount})" : ""));
+        table.AddRow(tagNameFormatter("Genres"),
+                     file.GenresCombined.EscapeMarkup() +
+                        (genreCount > 1 ? $" ({genreCount})" : ""));
 
         var bitrate = file.BitRate.ToString();
         var sampleRate = file.SampleRate.ToString("#,##0");
@@ -44,7 +45,7 @@ public class MediaFileViewer
         {
             table.AddRow(
                 tagNameFormatter("Composers"),
-                string.Join("; ", file.Composers).EscapeMarkup());
+                file.ComposersCombined.EscapeMarkup());
         }
 
         if (!string.IsNullOrWhiteSpace(file.Comments))
@@ -74,12 +75,12 @@ public class MediaFileViewer
 
         var rows = new List<string>
         {
-            GetCombinedArtists(file.AlbumArtists, file.Artists),
+            file.AlbumArtistsAndArtistsCombined,
             file.Album.EscapeMarkup(),
             file.TrackNo == 0 ? string.Empty : file.TrackNo.ToString().EscapeMarkup(),
             file.Title.EscapeMarkup(),
             file.Year == 0 ? string.Empty : file.Year.ToString(),
-            string.Join(", ", file.Genres).EscapeMarkup(),
+            file.GenresCombined.EscapeMarkup(),
             file.Duration.ToString("m\\:ss"),
             file.ReplayGainTrack.ToString()
         };
@@ -87,19 +88,5 @@ public class MediaFileViewer
         var markups = rows.Select(r => new Markup(r));
 
         return new TableRow(markups);
-
-        static string GetCombinedArtists(string[] albumArtists, string[] artists)
-        {
-            var artistString = string.Join(", ", artists).EscapeMarkup();
-
-            if (!albumArtists.Any())
-                return artistString;
-
-            var albumArtistString = string.Join(", ", albumArtists).EscapeMarkup();
-
-            return albumArtistString == artistString
-                ? artistString
-                : $"{albumArtistString} ({artistString})";
-        }
     }
 }

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -2,7 +2,7 @@ using Spectre.Console;
 
 namespace AudioTagger;
 
-public class MediaFileViewer
+public sealed class MediaFileViewer
 {
     public void PrintFileDetails(MediaFile file)
     {
@@ -67,7 +67,7 @@ public class MediaFileViewer
         AnsiConsole.Write(panel);
     }
 
-    public TableRow PrintFileSummary(MediaFile file)
+    public static TableRow PrintFileSummary(MediaFile file)
     {
         var rows = new List<string>
         {

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -6,8 +6,6 @@ public class MediaFileViewer
 {
     public void PrintFileDetails(MediaFile file)
     {
-        ArgumentNullException.ThrowIfNull(file);
-
         // TODO: Handle colors more gracefully.
         var tagNameFormatter = (string s) => "[grey]" + s +"[/]";
 
@@ -71,11 +69,9 @@ public class MediaFileViewer
 
     public TableRow PrintFileSummary(MediaFile file)
     {
-        ArgumentNullException.ThrowIfNull(file);
-
         var rows = new List<string>
         {
-            file.AlbumArtistsAndArtistsCombined,
+            file.AlbumArtistsAndArtistsCombined.EscapeMarkup(),
             file.Album.EscapeMarkup(),
             file.TrackNo == 0 ? string.Empty : file.TrackNo.ToString().EscapeMarkup(),
             file.Title.EscapeMarkup(),

--- a/AudioTagger.Console/Normalization.cs
+++ b/AudioTagger.Console/Normalization.cs
@@ -10,7 +10,7 @@ public class Normalization : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         if (!mediaFiles.Any())
         {

--- a/AudioTagger.Console/Normalization.cs
+++ b/AudioTagger.Console/Normalization.cs
@@ -5,7 +5,7 @@ namespace AudioTagger.Console;
 /// <summary>
 /// Normalize audio using ReplayGain.
 /// </summary>
-public class Normalization : IPathOperation
+public sealed class Normalization : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -53,7 +53,7 @@ internal static class OperationLibrary
             new Normalization()),
         new(
             new OperationFlags{"-g", "--genres"},
-            "Read artist genres to the settings file (Under development!)",
+            "Read artist all genres to the settings file.",
             new GenreExtractor()),
     };
 

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -71,7 +71,7 @@ internal static class OperationLibrary
                          .PathOperation;
     }
 
-    internal class Operation
+    internal sealed class Operation
     {
         public required List<string> Commands { get; set;}
         public required string Description { get; set; }

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -51,6 +51,10 @@ internal static class OperationLibrary
             new OperationFlags{"-n", "--normalize", "--replaygain"},
             "Apply track normalization.",
             new Normalization()),
+        new(
+            new OperationFlags{"-g", "--genres"},
+            "Read artist genres to the settings file (Under development!)",
+            new GenreExtractor()),
     };
 
     public static Dictionary<string, string> GenerateHelpTextPairs()
@@ -69,7 +73,7 @@ internal static class OperationLibrary
 
     internal class Operation
     {
-        public required List<string> Commands { get;set;}
+        public required List<string> Commands { get; set;}
         public required string Description { get; set; }
         public required IPathOperation PathOperation { get; set; }
 

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -53,7 +53,7 @@ internal static class OperationLibrary
             new Normalization()),
         new(
             new OperationFlags{"-g", "--genres"},
-            "Read artist all genres to the settings file.",
+            "Save the primary genre for each artist to the settings file.",
             new GenreExtractor()),
     };
 

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -20,9 +20,8 @@ public static class Program
             return;
         }
 
-        const string settingsFileName = "settings.json";
-        if (!EnsureSettingsFileExists(settingsFileName, printer)) return;
-        var settings = ReadSettings(settingsFileName, printer);
+        SettingsService.EnsureSettingsFileExists(printer);
+        var settings = SettingsService.ReadSettings(printer);
 
         var argQueue = new Queue<string>(args.Select(a => a.Trim()));
 
@@ -95,46 +94,6 @@ public static class Program
     private static IPathOperation? OperationFactory(string modeArg)
     {
         return OperationLibrary.GetPathOperation(modeArg);
-    }
-
-    private static Settings? ReadSettings(string fileName, IPrinter printer)
-    {
-        try
-        {
-            var text = File.ReadAllText(fileName);
-            return JsonSerializer.Deserialize<Settings>(text);
-        }
-        catch (FileNotFoundException)
-        {
-            printer.Print("Continuing with no settings since `settings.json` was not found. (See the readme file for more.)", appendLines: 1);
-            return null;
-        }
-        catch (JsonException ex)
-        {
-            printer.Print($"The settings file is invalid: {ex.Message}");
-            printer.Print("Continuing without settings...", appendLines: 1);
-            return null;
-        }
-    }
-
-    private static bool EnsureSettingsFileExists(string fileName, IPrinter printer)
-    {
-        if (File.Exists(fileName))
-            return true;
-
-        try
-        {
-            var json = JsonSerializer.Serialize(new Settings(),
-                                                new JsonSerializerOptions { WriteIndented = true });
-            File.WriteAllText(fileName, json);
-            printer.Print($"Created empty settings file \"{fileName}\" successfully.");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            printer.Error($"There was an error creating \"{fileName}\": {ex.Message}");
-            return false;
-        }
     }
 
     private static void PrintInstructions(IPrinter printer)

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -3,6 +3,7 @@ global using System.Linq;
 global using System.Collections.Generic;
 global using System.Collections.Immutable;
 global using System.IO;
+global using AudioTagger.Library.MediaFiles;
 using Spectre.Console;
 
 namespace AudioTagger.Console;

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -4,7 +4,6 @@ global using System.Collections.Generic;
 global using System.Collections.Immutable;
 global using System.IO;
 using Spectre.Console;
-using System.Text.Json;
 
 namespace AudioTagger.Console;
 
@@ -20,8 +19,9 @@ public static class Program
             return;
         }
 
-        SettingsService.EnsureSettingsFileExists(printer);
-        var settings = SettingsService.ReadSettings(printer);
+        var settings = SettingsService.ReadSettings(printer, true);
+        if (settings is null)
+            return;
 
         var argQueue = new Queue<string>(args.Select(a => a.Trim()));
 

--- a/AudioTagger.Console/SettingsService.cs
+++ b/AudioTagger.Console/SettingsService.cs
@@ -30,21 +30,22 @@ public static class SettingsService
                 return null;
 
             var text = File.ReadAllText(_settingsFileName);
-            return JsonSerializer.Deserialize<Settings>(text) ?? throw new JsonException();
+            return JsonSerializer.Deserialize<Settings>(text)
+                   ?? throw new JsonException();
         }
         catch (FileNotFoundException)
         {
-            printer.Print($"Settings file \"{_settingsFileName}\" was unexpectedly not found");
+            printer.Error($"Settings file \"{_settingsFileName}\" was unexpectedly not found.");
             return null;
         }
         catch (JsonException ex)
         {
-            printer.Print($"The settings file is invalid: {ex.Message}");
+            printer.Error($"The settings file is invalid: {ex.Message}");
             return null;
         }
         catch (Exception ex)
         {
-            printer.Print($"ERROR: {ex.Message}");
+            printer.Error(ex.Message);
             return null;
         }
     }
@@ -72,7 +73,7 @@ public static class SettingsService
         }
         catch (JsonException ex)
         {
-            printer.Print($"The settings file is invalid: {ex.Message}");
+            printer.Error($"The settings file is invalid: {ex.Message}");
             return false;
             // throw new InvalidOperationException();
         }

--- a/AudioTagger.Console/SettingsService.cs
+++ b/AudioTagger.Console/SettingsService.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Spectre.Console;
+
+namespace AudioTagger.Console;
+
+public static class SettingsService
+{
+    private const string _settingsFileName = "settings.json";
+
+    public static bool EnsureSettingsFileExists(IPrinter printer)
+    {
+        if (File.Exists(_settingsFileName))
+            return true;
+
+        try
+        {
+            return WriteSettingsFile(new Settings());
+        }
+        catch (Exception ex)
+        {
+            printer.Error($"There was an error creating \"{_settingsFileName}\": {ex.Message}");
+            return false;
+        }
+    }
+
+    public static Settings? ReadSettings(IPrinter printer)
+    {
+        try
+        {
+            var text = File.ReadAllText(_settingsFileName);
+            return JsonSerializer.Deserialize<Settings>(text);
+        }
+        catch (FileNotFoundException)
+        {
+            // printer.Print("Continuing with no settings since `settings.json` was not found. (See the readme file for more.)", appendLines: 1);
+            return null;
+        }
+        catch (JsonException ex)
+        {
+            // printer.Print($"The settings file is invalid: {ex.Message}");
+            // printer.Print("Continuing without settings...", appendLines: 1);
+            return null;
+        }
+    }
+
+    public static bool WriteSettingsFile(Settings settings)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(
+                settings,
+                new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(System.Text.Unicode.UnicodeRanges.All)
+                });
+            File.WriteAllText(_settingsFileName, json);
+            return true;
+        }
+        catch (FileNotFoundException)
+        {
+            // printer.Print("Continuing with no settings since `settings.json` was not found. (See the readme file for more.)", appendLines: 1);
+            // return null;
+            throw new InvalidOperationException();
+        }
+        catch (JsonException ex)
+        {
+            // printer.Print($"The settings file is invalid: {ex.Message}");
+            // printer.Print("Continuing without settings...", appendLines: 1);
+            // return null;
+            throw new InvalidOperationException();
+        }
+    }
+}

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -3,38 +3,28 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class SpectrePrinter : IPrinter
+public sealed class SpectrePrinter : IPrinter
 {
-    private static void PrependLines(byte lines)
+    private static void AddLines(byte lines)
     {
         if (lines == 0)
             return;
 
-        for (var prepend = 0; prepend < lines; prepend++)
-            WriteLine();
+        WriteLine(Enumerable.Repeat(Environment.NewLine, lines));
     }
 
-    private static void AppendLines(byte lines)
-    {
-        if (lines == 0)
-            return;
-
-        for (var append = 0; append < lines; append++)
-            WriteLine();
-    }
-
-    public void Print(string message, byte prependLines = 0, byte appendLines = 0, string prependText = "",
-                      ConsoleColor? fgColor = null, ConsoleColor? bgColor = null)
+    public void Print(string message, byte prependLines = 0, byte appendLines = 0,
+                      string prependText = "", ConsoleColor? fgColor = null, ConsoleColor? bgColor = null)
     {
         if (string.IsNullOrWhiteSpace(message))
             throw new ArgumentNullException(nameof(message), "Message cannot be empty");
 
-        PrependLines(prependLines);
+        AddLines(prependLines);
 
         var subString = new LineSubString(message, fgColor, bgColor);
         AnsiConsole.MarkupLine(subString.GetSpectreString());
 
-        AppendLines(appendLines);
+        AddLines(appendLines);
     }
 
     public void Print(string message, ResultType type, byte prependLines = 0,
@@ -47,25 +37,31 @@ public class SpectrePrinter : IPrinter
     public void Print(IEnumerable<LineSubString> lineParts,
                       byte prependLines = 0, byte appendLines = 1)
     {
-        PrependLines(prependLines);
+        AddLines(prependLines);
 
         if (!lineParts.Any())
             return;
 
-        foreach (var linePart in lineParts)
+        // foreach (var linePart in lineParts)
+        // {
+        //     AnsiConsole.Markup(
+        //         new LineSubString(linePart.Text, linePart.FgColor, linePart.BgColor)
+        //             .GetSpectreString());
+        // }
+        lineParts.ToList().ForEach(p =>
         {
             AnsiConsole.Markup(
-                new LineSubString(linePart.Text, linePart.FgColor, linePart.BgColor)
+                new LineSubString(p.Text, p.FgColor, p.BgColor)
                     .GetSpectreString());
-        }
+        });
 
-        AppendLines(appendLines);
+        AddLines(appendLines);
     }
 
     public void Print(IEnumerable<OutputLine> lines,
                       byte prependLines = 0, byte appendLines = 1)
     {
-        PrependLines(prependLines);
+        AddLines(prependLines);
 
         if (!lines.Any())
             return; // TODO: Think about this.
@@ -82,7 +78,7 @@ public class SpectrePrinter : IPrinter
             }
         }
 
-        AppendLines(appendLines);
+        AddLines(appendLines);
     }
 
     public void Error(string message) => Print(message, 1, 1, "ERROR: ");

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -5,7 +5,11 @@ namespace AudioTagger.Console;
 
 public sealed class SpectrePrinter : IPrinter
 {
-    private static void AddLines(byte count)
+    /// <summary>
+    /// Prints the requested number of blank lines.
+    /// </summary>
+    /// <param name="count"></param>
+    private static void PrintEmptyLines(byte count)
     {
         if (count == 0)
             return;
@@ -19,12 +23,12 @@ public sealed class SpectrePrinter : IPrinter
         if (string.IsNullOrWhiteSpace(message))
             throw new ArgumentNullException(nameof(message), "Message cannot be empty");
 
-        AddLines(prependLines);
+        PrintEmptyLines(prependLines);
 
         var subString = new LineSubString(message, fgColor, bgColor);
         AnsiConsole.MarkupLine(subString.GetSpectreString());
 
-        AddLines(appendLines);
+        PrintEmptyLines(appendLines);
     }
 
     public void Print(string message, ResultType type, byte prependLines = 0,
@@ -37,7 +41,7 @@ public sealed class SpectrePrinter : IPrinter
     public void Print(IEnumerable<LineSubString> lineParts,
                       byte prependLines = 0, byte appendLines = 1)
     {
-        AddLines(prependLines);
+        PrintEmptyLines(prependLines);
 
         if (!lineParts.Any())
             return;
@@ -49,13 +53,13 @@ public sealed class SpectrePrinter : IPrinter
                     .GetSpectreString());
         });
 
-        AddLines(appendLines);
+        PrintEmptyLines(appendLines);
     }
 
     public void Print(IEnumerable<OutputLine> lines,
                       byte prependLines = 0, byte appendLines = 1)
     {
-        AddLines(prependLines);
+        PrintEmptyLines(prependLines);
 
         if (!lines.Any())
             return; // TODO: Think about this.
@@ -72,7 +76,7 @@ public sealed class SpectrePrinter : IPrinter
             }
         }
 
-        AddLines(appendLines);
+        PrintEmptyLines(appendLines);
     }
 
     public void Error(string message) => Print(message, 1, 1, "ERROR: ");

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -5,12 +5,12 @@ namespace AudioTagger.Console;
 
 public sealed class SpectrePrinter : IPrinter
 {
-    private static void AddLines(byte lines)
+    private static void AddLines(byte count)
     {
-        if (lines == 0)
+        if (count == 0)
             return;
 
-        WriteLine(Enumerable.Repeat(Environment.NewLine, lines));
+        Write(string.Concat(Enumerable.Repeat(Environment.NewLine, count)));
     }
 
     public void Print(string message, byte prependLines = 0, byte appendLines = 0,

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -42,12 +42,6 @@ public sealed class SpectrePrinter : IPrinter
         if (!lineParts.Any())
             return;
 
-        // foreach (var linePart in lineParts)
-        // {
-        //     AnsiConsole.Markup(
-        //         new LineSubString(linePart.Text, linePart.FgColor, linePart.BgColor)
-        //             .GetSpectreString());
-        // }
         lineParts.ToList().ForEach(p =>
         {
             AnsiConsole.Markup(
@@ -82,35 +76,6 @@ public sealed class SpectrePrinter : IPrinter
     }
 
     public void Error(string message) => Print(message, 1, 1, "ERROR: ");
-
-    // private void PrintColor(LineSubString lineSubString)
-    // {
-    //     PrintColor(lineSubString.Text, lineSubString.FgColor, lineSubString.BgColor);
-    // }
-
-    // private void PrintColor(string text, ConsoleColor? fgColor,
-    //                                ConsoleColor? bgColor = null,
-    //                                bool addLineBreak = false)
-    // {
-    //     if (fgColor.HasValue)
-    //         System.Console.ForegroundColor = fgColor.Value;
-
-    //     if (bgColor.HasValue)
-    //         BackgroundColor = bgColor.Value;
-
-    //     Write(text);
-
-    //     if (addLineBreak)
-    //         WriteLine();
-
-    //     ResetColor();
-    // }
-
-    // // TODO: Check whether we can delete this.
-    // private void PrintColor()
-    // {
-    //     WriteLine();
-    // }
 
     public char GetResultSymbol(ResultType type)
     {

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace AudioTagger.Console;
 
-public class TagDuplicateFinder : IPathOperation
+public sealed class TagDuplicateFinder : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -8,7 +8,7 @@ public class TagDuplicateFinder : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         if (!mediaFiles.Any())
         {

--- a/AudioTagger.Console/TagStats.cs
+++ b/AudioTagger.Console/TagStats.cs
@@ -9,7 +9,7 @@ public class TagStats : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         if (!mediaFiles.Any())
         {

--- a/AudioTagger.Console/TagStats.cs
+++ b/AudioTagger.Console/TagStats.cs
@@ -4,7 +4,7 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class TagStats : IPathOperation
+public sealed class TagStats : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
@@ -140,7 +140,7 @@ public class TagStats : IPathOperation
         }
     }
 
-    private class TitleComparer : IEqualityComparer<string>
+    private sealed class TitleComparer : IEqualityComparer<string>
     {
         public bool Equals(string? x, string? y)
         {

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -53,7 +53,7 @@ public class TagUpdater : IPathOperation
     /// </summary>
     /// <returns>A bool indicating whether the following file should be processed.</returns>
     private static bool UpdateTags(MediaFile mediaFile,
-                                   IRegexCollection regexCollection,
+                                   RegexCollection regexCollection,
                                    IPrinter printer,
                                    Settings settings,
                                    ref bool doConfirm)
@@ -61,7 +61,7 @@ public class TagUpdater : IPathOperation
         // TODO: Refactor cancellation so this isn't needed.
         const bool shouldCancel = false;
 
-        var match = regexCollection.GetFirstFileMatch(mediaFile.FileNameOnly);
+        var match = regexCollection.GetFirstMatch(mediaFile.FileNameOnly);
 
         // If there are no regex matches against the filename, we cannot continue.
         if (match == null)

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -3,7 +3,7 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class TagUpdater : IPathOperation
+public sealed class TagUpdater : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -25,7 +25,7 @@ public class TagUpdater : IPathOperation
         {
             try
             {
-                cancelRequested = UpdateTags(mediaFile, regexCollection, printer, ref doConfirm);
+                cancelRequested = UpdateTags(mediaFile, regexCollection, printer, settings, ref doConfirm);
 
                 if (cancelRequested)
                     break;
@@ -49,7 +49,11 @@ public class TagUpdater : IPathOperation
     /// Make proposed tag updates to the specified file if the user agrees.
     /// </summary>
     /// <returns>A bool indicating whether the following file should be processed.</returns>
-    private static bool UpdateTags(MediaFile mediaFile, IRegexCollection regexCollection, IPrinter printer, ref bool doConfirm)
+    private static bool UpdateTags(MediaFile mediaFile,
+                                   IRegexCollection regexCollection,
+                                   IPrinter printer,
+                                   Settings settings,
+                                   ref bool doConfirm)
     {
         // TODO: Refactor cancellation so this isn't needed.
         const bool shouldCancel = false;
@@ -75,7 +79,7 @@ public class TagUpdater : IPathOperation
             return shouldCancel;
         }
 
-        var updateableFields = new UpdatableFields(matchedTags);
+        var updateableFields = new UpdatableFields(matchedTags, settings);
 
         var proposedUpdates = updateableFields.GetUpdateKeyValuePairs(mediaFile);
 
@@ -119,7 +123,7 @@ public class TagUpdater : IPathOperation
 
             if (response == no)
             {
-                printer.Print("No updates made", ResultType.Neutral, 0, 1);
+                printer.Print("No updates made.", ResultType.Neutral, 0, 1);
                 return shouldCancel;
             }
 
@@ -130,7 +134,6 @@ public class TagUpdater : IPathOperation
             }
         }
 
-        // Make the tag updates
         UpdateFileTags(mediaFile, updateableFields);
         try
         {
@@ -152,7 +155,8 @@ public class TagUpdater : IPathOperation
     /// </summary>
     /// <param name="fileData"></param>
     /// <param name="updateableFields"></param>
-    private static void UpdateFileTags(MediaFile fileData, UpdatableFields updateableFields)
+    private static void UpdateFileTags(MediaFile fileData,
+                                       UpdatableFields updateableFields)
     {
         if (updateableFields.Title != null && updateableFields.Title != fileData.Title)
         {

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -10,9 +10,6 @@ public class TagUpdater : IPathOperation
                       IPrinter printer,
                       Settings settings)
     {
-        if (settings is null)
-            throw new InvalidOperationException("Settings cannot be null");
-
         var cancelRequested = false;
         var doConfirm = true;
         var errorFiles = new List<string>();

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -8,8 +8,11 @@ public class TagUpdater : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
+        if (settings is null)
+            throw new InvalidOperationException("Settings cannot be null");
+
         var cancelRequested = false;
         var doConfirm = true;
         var errorFiles = new List<string>();
@@ -25,7 +28,7 @@ public class TagUpdater : IPathOperation
         {
             try
             {
-                cancelRequested = UpdateTags(mediaFile, regexCollection, printer, settings, ref doConfirm);
+                cancelRequested = UpdateTags(mediaFile, regexCollection, printer, settings!, ref doConfirm);
 
                 if (cancelRequested)
                     break;

--- a/AudioTagger.Console/TagUpdaterSingle.cs
+++ b/AudioTagger.Console/TagUpdaterSingle.cs
@@ -14,7 +14,7 @@ public class TagUpdaterSingle : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         if (!mediaFiles.Any())
         {

--- a/AudioTagger.Console/TagUpdaterSingle.cs
+++ b/AudioTagger.Console/TagUpdaterSingle.cs
@@ -54,15 +54,15 @@ public class TagUpdaterSingle : IPathOperation
                 UpdateTags(file, tagName, tagValue, updateType);
                 successCount++;
             }
-            catch (FormatException e)
+            catch (FormatException ex)
             {
                 failureCount++;
-                printer.Print($"❌ ERROR: {e.Message} ({file.Path})");
+                printer.Error($"{ex.Message} ({file.Path})");
             }
-            catch
+            catch (Exception ex)
             {
                 failureCount++;
-                printer.Print($"❌ UNEXPECTED ERROR: {file.Path}");
+                printer.Error($"Error for \"{file.Path}\": {ex.Message}");
             }
         }
 

--- a/AudioTagger.Console/TagUpdaterSingle.cs
+++ b/AudioTagger.Console/TagUpdaterSingle.cs
@@ -5,7 +5,7 @@ namespace AudioTagger.Console;
 /// <summary>
 /// Updates a single supported tag to a specified value for all files in a specific path.
 /// </summary>
-public class TagUpdaterSingle : IPathOperation
+public sealed class TagUpdaterSingle : IPathOperation
 {
     private enum TagUpdateType { Overwrite, Prepend, Append }
 

--- a/AudioTagger.Console/TagUpdaterYearOnly.cs
+++ b/AudioTagger.Console/TagUpdaterYearOnly.cs
@@ -2,7 +2,7 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class TagUpdaterYearOnly : IPathOperation
+public sealed class TagUpdaterYearOnly : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Console/TagUpdaterYearOnly.cs
+++ b/AudioTagger.Console/TagUpdaterYearOnly.cs
@@ -7,7 +7,7 @@ public class TagUpdaterYearOnly : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         var isCancelled = false;
         var doConfirm = true;

--- a/AudioTagger.Console/TagViewer.cs
+++ b/AudioTagger.Console/TagViewer.cs
@@ -5,7 +5,7 @@ public class TagViewer : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         ArgumentNullException.ThrowIfNull(mediaFiles);
 

--- a/AudioTagger.Console/TagViewer.cs
+++ b/AudioTagger.Console/TagViewer.cs
@@ -1,6 +1,6 @@
 ﻿namespace AudioTagger.Console;
 
-public class TagViewer : IPathOperation
+public sealed class TagViewer : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Console/TagViewerSummary.cs
+++ b/AudioTagger.Console/TagViewerSummary.cs
@@ -7,7 +7,7 @@ public class TagViewerSummary : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         ArgumentNullException.ThrowIfNull(mediaFiles);
 

--- a/AudioTagger.Console/TagViewerSummary.cs
+++ b/AudioTagger.Console/TagViewerSummary.cs
@@ -2,7 +2,7 @@ using Spectre.Console;
 
 namespace AudioTagger.Console;
 
-public class TagViewerSummary : IPathOperation
+public sealed class TagViewerSummary : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
                       DirectoryInfo workingDirectory,
@@ -73,7 +73,7 @@ public class TagViewerSummary : IPathOperation
         {
             try
             {
-                table.AddRow(viewer.PrintFileSummary(mediaFile));
+                table.AddRow(MediaFileViewer.PrintFileSummary(mediaFile));
             }
             catch (TagLib.CorruptFileException e)
             {

--- a/AudioTagger.Library/IPathOperation.cs
+++ b/AudioTagger.Library/IPathOperation.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 

--- a/AudioTagger.Library/IPathOperation.cs
+++ b/AudioTagger.Library/IPathOperation.cs
@@ -7,5 +7,5 @@ public interface IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> filesData,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null);
+                      Settings settings);
 }

--- a/AudioTagger.Library/IPrinter.cs
+++ b/AudioTagger.Library/IPrinter.cs
@@ -1,4 +1,6 @@
-﻿namespace AudioTagger;
+﻿using AudioTagger.Library.MediaFiles;
+
+namespace AudioTagger;
 
 public interface IPrinter
 {

--- a/AudioTagger.Library/IRegexCollection.cs
+++ b/AudioTagger.Library/IRegexCollection.cs
@@ -1,9 +1,0 @@
-using System.Text.RegularExpressions;
-
-namespace AudioTagger;
-
-public interface IRegexCollection
-{
-    IReadOnlyCollection<string> Patterns { get; }
-    Match? GetFirstFileMatch(string fileName);
-}

--- a/AudioTagger.Library/LineSubstring.cs
+++ b/AudioTagger.Library/LineSubstring.cs
@@ -1,6 +1,6 @@
 ﻿namespace AudioTagger;
 
-public class LineSubString
+public sealed class LineSubString
 {
     public string Text { get; set; }
     public ConsoleColor? FgColor { get; set; }

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -62,7 +62,7 @@ public class MediaFile
                          .ToArray();
     }
 
-    public string ArtistsCombined => string.Join(_separator, AlbumArtists);
+    public string ArtistsCombined => string.Join(_separator, Artists);
 
     public string Album
     {

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -2,8 +2,6 @@
 
 public class MediaFile
 {
-    private const string _separator = "; ";
-
     public string Path { get; }
     private readonly TagLib.File _taggedFile;
 
@@ -36,19 +34,6 @@ public class MediaFile
                          .ToArray();
     }
 
-    public string AlbumArtistsCombined => string.Join(_separator, AlbumArtists);
-
-    public string AlbumArtistsAndArtistsCombined
-    {
-        get
-        {
-            if (!AlbumArtists.Any() || AlbumArtistsCombined == ArtistsCombined)
-                return ArtistsCombined;
-
-            return $"{AlbumArtistsCombined} ({ArtistsCombined})";
-        }
-    }
-
     // TODO: Note why Performers is used instead of Artists.
     public string[] Artists
     {
@@ -61,8 +46,6 @@ public class MediaFile
                          .Select(a => a.Trim().Normalize())
                          .ToArray();
     }
-
-    public string ArtistsCombined => string.Join(_separator, Artists);
 
     public string Album
     {
@@ -100,8 +83,6 @@ public class MediaFile
                                         ?? Array.Empty<string>();
     }
 
-    public string GenresCombined => string.Join(_separator, Genres);
-
     public string[] Composers
     {
         get => _taggedFile.Tag.Composers?.Select(c => c?.Trim()?.Normalize()
@@ -114,8 +95,6 @@ public class MediaFile
                                                  .ToArray()
                                            ?? Array.Empty<string>();
     }
-
-    public string ComposersCombined => string.Join(_separator, AlbumArtists);
 
     public string Lyrics
     {

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -2,7 +2,7 @@
 
 public class MediaFile
 {
-    private const string _separator = ", ";
+    private const string _separator = "; ";
 
     public string Path { get; }
     private readonly TagLib.File _taggedFile;
@@ -37,6 +37,17 @@ public class MediaFile
     }
 
     public string AlbumArtistsCombined => string.Join(_separator, AlbumArtists);
+
+    public string AlbumArtistsAndArtistsCombined
+    {
+        get
+        {
+            if (!AlbumArtists.Any() || AlbumArtistsCombined == ArtistsCombined)
+                return ArtistsCombined;
+
+            return $"{AlbumArtistsCombined} ({ArtistsCombined})";
+        }
+    }
 
     // TODO: Note why Performers is used instead of Artists.
     public string[] Artists
@@ -89,6 +100,8 @@ public class MediaFile
                                         ?? Array.Empty<string>();
     }
 
+    public string GenresCombined => string.Join(_separator, Genres);
+
     public string[] Composers
     {
         get => _taggedFile.Tag.Composers?.Select(c => c?.Trim()?.Normalize()
@@ -101,6 +114,8 @@ public class MediaFile
                                                  .ToArray()
                                            ?? Array.Empty<string>();
     }
+
+    public string ComposersCombined => string.Join(_separator, AlbumArtists);
 
     public string Lyrics
     {

--- a/AudioTagger.Library/MediaFile.cs
+++ b/AudioTagger.Library/MediaFile.cs
@@ -1,9 +1,9 @@
-﻿using System.Text;
-
-namespace AudioTagger;
+﻿namespace AudioTagger;
 
 public class MediaFile
 {
+    private const string _separator = ", ";
+
     public string Path { get; }
     private readonly TagLib.File _taggedFile;
 
@@ -36,6 +36,8 @@ public class MediaFile
                          .ToArray();
     }
 
+    public string AlbumArtistsCombined => string.Join(_separator, AlbumArtists);
+
     // TODO: Note why Performers is used instead of Artists.
     public string[] Artists
     {
@@ -48,6 +50,8 @@ public class MediaFile
                          .Select(a => a.Trim().Normalize())
                          .ToArray();
     }
+
+    public string ArtistsCombined => string.Join(_separator, AlbumArtists);
 
     public string Album
     {

--- a/AudioTagger.Library/MediaFileExtensionMethods.cs
+++ b/AudioTagger.Library/MediaFileExtensionMethods.cs
@@ -1,0 +1,47 @@
+namespace AudioTagger;
+
+public static class MediaFileExtensionMethods
+{
+    /// <summary>
+    /// Joins a collection into one string using a specified separator string.
+    /// </summary>
+    /// <param name="collection"></param>
+    /// <param name="separator"></param>
+    /// <returns>A joined string. Never returns null.</returns>
+    public static string Join(this IEnumerable<string> collection, string separator = "; ")
+    {
+        return collection is null
+            ? string.Empty
+            : string.Join(separator, collection);
+    }
+
+    /// <summary>
+    /// Joins two collections into one formatted string. If their contents differ, then both will be included
+    /// with the secondary collection placed within parentheses after the primary collection.
+    /// </summary>
+    /// <param name="primary">This collection is given priority.</param>
+    /// <param name="secondary">This collection will not be added if it is identical to the primary one.</param>
+    /// <param name="separator">Applies to each collection separately.</param>
+    /// <returns>A combined string. Never returns null. Example: "primary 1; primary 2 (secondary 1; secondary 2)"</returns>
+    public static string JoinWith(this IEnumerable<string> primary, IEnumerable<string> secondary, string separator = "; ")
+    {
+        if (primary is null && secondary is null)
+            return string.Empty;
+
+        string joiner(IEnumerable<string> collection) => string.Join(separator, collection);
+
+        if (primary?.Any() != true)
+            return joiner(secondary);
+
+        if (secondary?.Any() != true)
+            return joiner(primary);
+
+        if (primary.Count() != secondary.Count())
+            return $"{joiner(primary)} ({joiner(secondary)})";
+
+        if (primary.Except(secondary).Any()) // Collections are not identical (despite equal counts)
+            return $"{joiner(primary)} ({joiner(secondary)})";
+
+        return joiner(primary); // Identical collection of equal length, so only print one
+    }
+}

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -1,4 +1,4 @@
-﻿namespace AudioTagger;
+﻿namespace AudioTagger.Library.MediaFiles;
 
 public class MediaFile
 {

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -1,6 +1,6 @@
 ﻿namespace AudioTagger.Library.MediaFiles;
 
-public class MediaFile
+public sealed class MediaFile
 {
     public string Path { get; }
     private readonly TagLib.File _taggedFile;

--- a/AudioTagger.Library/MediaFiles/MediaFileExtensionMethods.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFileExtensionMethods.cs
@@ -1,4 +1,4 @@
-namespace AudioTagger;
+namespace AudioTagger.Library.MediaFiles;
 
 public static class MediaFileExtensionMethods
 {

--- a/AudioTagger.Library/MediaFiles/MediaFileFactory.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFileFactory.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 
-namespace AudioTagger;
+namespace AudioTagger.Library.MediaFiles;
 
 public static class MediaFileFactory
 {

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -56,8 +56,7 @@ public class OutputLine
     }
 
     public static OutputLine TagDataWithHeader(string tagName, string tagData,
-                                        string prependLine = "",
-                                        ConsoleColor headerColor = ConsoleColor.DarkGray)
+                                        string prependLine = "")
     {
         return TagDataWithHeader(
             tagName,
@@ -73,7 +72,7 @@ public class OutputLine
         var lines = new List<OutputLine>
         {
             TagDataWithHeader("Title", fileData.Title),
-            TagDataWithHeader("Artist(s)", fileData.ArtistsCombined),
+            TagDataWithHeader("Artist(s)", fileData.Artists.Join()),
             TagDataWithHeader("Album", fileData.Album),
             TagDataWithHeader("Year", fileData.Year.ToString()),
             TagDataWithHeader("Duration", fileData.Duration.ToString("m\\:ss"))
@@ -101,7 +100,7 @@ public class OutputLine
                 }));
 
         if (fileData.Composers?.Length > 0)
-            lines.Add(TagDataWithHeader("Composers", fileData.ComposersCombined));
+            lines.Add(TagDataWithHeader("Composers", fileData.Composers.Join()));
 
         if (!string.IsNullOrWhiteSpace(fileData.Comments))
             lines.Add(TagDataWithHeader("Comment", fileData.Comments));
@@ -114,14 +113,14 @@ public class OutputLine
         var lines = new Dictionary<string, string>
         {
             { "Title", fileData.Title },
-            { "Artist(s)", fileData.ArtistsCombined },
+            { "Artist(s)", fileData.Artists.Join() },
             { "Album", fileData.Album },
             { "Year", fileData.Year.ToString() },
             { "Duration", fileData.Duration.ToString("m\\:ss") }
         };
 
         var genreCount = fileData.Genres.Length;
-        lines.Add("Genre(s)", fileData.GenresCombined +
+        lines.Add("Genre(s)", fileData.Genres.Join() +
                               (genreCount > 1 ? $" ({genreCount})" : ""));
 
         var bitrate = fileData.BitRate.ToString();

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -2,7 +2,7 @@ using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 
-public class OutputLine
+public sealed class OutputLine
 {
     public List<LineSubString> Line { get; set; } = new List<LineSubString>();
 

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -73,7 +73,7 @@ public class OutputLine
         var lines = new List<OutputLine>
         {
             TagDataWithHeader("Title", fileData.Title),
-            TagDataWithHeader("Artist(s)", string.Join(", ", fileData.Artists)),
+            TagDataWithHeader("Artist(s)", fileData.ArtistsCombined),
             TagDataWithHeader("Album", fileData.Album),
             TagDataWithHeader("Year", fileData.Year.ToString()),
             TagDataWithHeader("Duration", fileData.Duration.ToString("m\\:ss"))
@@ -101,7 +101,7 @@ public class OutputLine
                 }));
 
         if (fileData.Composers?.Length > 0)
-            lines.Add(TagDataWithHeader($"Composers", string.Join("; ", fileData.Composers)));
+            lines.Add(TagDataWithHeader("Composers", fileData.ComposersCombined));
 
         if (!string.IsNullOrWhiteSpace(fileData.Comments))
             lines.Add(TagDataWithHeader("Comment", fileData.Comments));
@@ -114,14 +114,14 @@ public class OutputLine
         var lines = new Dictionary<string, string>
         {
             { "Title", fileData.Title },
-            { "Artist(s)", string.Join(", ", fileData.Artists) },
+            { "Artist(s)", fileData.ArtistsCombined },
             { "Album", fileData.Album },
             { "Year", fileData.Year.ToString() },
             { "Duration", fileData.Duration.ToString("m\\:ss") }
         };
 
         var genreCount = fileData.Genres.Length;
-        lines.Add("Genre(s)", string.Join(", ", fileData.Genres) +
+        lines.Add("Genre(s)", fileData.GenresCombined +
                               (genreCount > 1 ? $" ({genreCount})" : ""));
 
         var bitrate = fileData.BitRate.ToString();

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -1,3 +1,5 @@
+using AudioTagger.Library.MediaFiles;
+
 namespace AudioTagger;
 
 public class OutputLine

--- a/AudioTagger.Library/RegexCollection.cs
+++ b/AudioTagger.Library/RegexCollection.cs
@@ -2,7 +2,7 @@
 
 namespace AudioTagger;
 
-public class RegexCollection : IRegexCollection
+public sealed record class RegexCollection
 {
     /// <summary>
     /// The regexes used for reading tags from names.
@@ -24,18 +24,20 @@ public class RegexCollection : IRegexCollection
                           .Distinct()
                           .ToList();
     }
+}
 
+public static class RegexCollectionExtensionMethods
+{
     /// <summary>
     /// Returns the first found regex matches for a filename, or null if none.
     /// </summary>
     /// <returns>Matched tag data; otherwise, null if no matches are found.</returns>
-    public Match? GetFirstFileMatch(string fileName)
+    public static Match? GetFirstMatch(this RegexCollection regexes,
+                                       string fileName)
     {
-        foreach (var pattern in Patterns)
+        foreach (var pattern in regexes.Patterns)
         {
-            var match = Regex.Match(fileName,
-                                    pattern,
-                                    RegexOptions.CultureInvariant);
+            var match = Regex.Match(fileName, pattern, RegexOptions.CultureInvariant);
 
             if (match.Success)
                 return match;

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -5,7 +5,7 @@ using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 
-public class FileRenamer : IPathOperation
+public sealed class FileRenamer : IPathOperation
 {
     public void Start(IReadOnlyCollection<MediaFile> filesData,
                       DirectoryInfo workingDirectory,

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text;
 using System.Globalization;
+using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -10,7 +10,7 @@ public class FileRenamer : IPathOperation
     public void Start(IReadOnlyCollection<MediaFile> filesData,
                       DirectoryInfo workingDirectory,
                       IPrinter printer,
-                      Settings? settings = null)
+                      Settings settings)
     {
         foreach (var fileData in filesData)
         {

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -49,10 +49,10 @@ public class FileRenamer : IPathOperation
 
         var newFileName = new StringBuilder();
 
-        var artist = fileData.ArtistsCombined;
+        var artist = fileData.Artists.Join();
         var title = fileData.Title;
         var year = fileData.Year.ToString(CultureInfo.InvariantCulture);
-        var genre = fileData.GenresCombined;
+        var genre = fileData.Genres.Join();
 
         if (!string.IsNullOrWhiteSpace(artist))
             newFileName.Append(artist).Append(" - ");

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -49,10 +49,10 @@ public class FileRenamer : IPathOperation
 
         var newFileName = new StringBuilder();
 
-        var artist = string.Join("; ", fileData.Artists);
+        var artist = fileData.ArtistsCombined;
         var title = fileData.Title;
         var year = fileData.Year.ToString(CultureInfo.InvariantCulture);
-        var genre = string.Join("; ", fileData.Genres);
+        var genre = fileData.GenresCombined;
 
         if (!string.IsNullOrWhiteSpace(artist))
             newFileName.Append(artist).Append(" - ");

--- a/AudioTagger.Library/Results.cs
+++ b/AudioTagger.Library/Results.cs
@@ -9,7 +9,7 @@ public enum ResultType
     Unknown
 }
 
-public record ResultProperties(ConsoleColor? Color, string Symbol = "");
+public sealed record ResultProperties(ConsoleColor? Color, string Symbol = "");
 
 public static class ResultsMap
 {

--- a/AudioTagger.Library/Results.cs
+++ b/AudioTagger.Library/Results.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace AudioTagger;
+﻿namespace AudioTagger;
 
 public enum ResultType
 {

--- a/AudioTagger.Library/Settings.cs
+++ b/AudioTagger.Library/Settings.cs
@@ -2,7 +2,7 @@ using System.Text.Json.Serialization;
 
 namespace AudioTagger;
 
-public record Settings
+public sealed record Settings
 {
     [JsonPropertyName("duplicates")]
     public Duplicates Duplicates { get; set; } = new();
@@ -17,13 +17,13 @@ public record Settings
     public Dictionary<string, string>? ArtistGenres { get; set; } = new();
 }
 
-public record Duplicates
+public sealed record Duplicates
 {
     [JsonPropertyName("titleReplacements")]
     public ImmutableList<string>? TitleReplacements { get; set; }
 }
 
-public record Tagging
+public sealed record Tagging
 {
     [JsonPropertyName("regexPatterns")]
     public ImmutableList<string>? RegexPatterns { get; set; }

--- a/AudioTagger.Library/Settings.cs
+++ b/AudioTagger.Library/Settings.cs
@@ -12,6 +12,9 @@ public record Settings
 
     [JsonPropertyName("renamePatterns")]
     public ImmutableList<string>? RenamePatterns { get; set; }
+
+    [JsonPropertyName("artistGenres")]
+    public Dictionary<string, string>? ArtistGenres { get; set; } = new();
 }
 
 public record Duplicates

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -4,7 +4,7 @@ using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 
-public class UpdatableFields
+public sealed class UpdatableFields
 {
     public string[]? AlbumArtists { get; }
     public string[]? Artists { get; }

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -21,7 +21,7 @@ public sealed class UpdatableFields
     /// maps the data to the correct tag name property.
     /// </summary>
     /// <param name="matchedGroups"></param>
-    public UpdatableFields(IEnumerable<Group> matchedGroups, Settings? settings = null)
+    public UpdatableFields(IEnumerable<Group> matchedGroups, Settings settings)
     {
         ArgumentNullException.ThrowIfNull(matchedGroups);
 

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -89,6 +89,8 @@ public class UpdatableFields
         // If no genre was manually passed in, check the settings for one.
         if ((Genres?.Any() != true) &&
             settings?.ArtistGenres is not null &&
+            settings.ArtistGenres.Any() &&
+            Artists is not null &&
             settings.ArtistGenres.ContainsKey(Artists[0]))
         {
             Genres = new[] { settings.ArtistGenres[Artists[0]] };

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -20,7 +20,7 @@ public class UpdatableFields
     /// maps the data to the correct tag name property.
     /// </summary>
     /// <param name="matchedGroups"></param>
-    public UpdatableFields(IEnumerable<Group> matchedGroups)
+    public UpdatableFields(IEnumerable<Group> matchedGroups, Settings? settings = null)
     {
         ArgumentNullException.ThrowIfNull(matchedGroups);
 
@@ -84,6 +84,14 @@ public class UpdatableFields
                 TrackNo = uint.TryParse(element.Value, out var parsed) ? parsed : null;
                 Count++;
             }
+        }
+
+        // If no genre was manually passed in, check the settings for one.
+        if ((Genres?.Any() != true) &&
+            settings?.ArtistGenres is not null &&
+            settings.ArtistGenres.ContainsKey(Artists[0]))
+        {
+            Genres = new[] { settings.ArtistGenres[Artists[0]] };
         }
     }
 

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using System.Globalization;
+using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
 

--- a/AudioTagger.Tests/RegexTests.cs
+++ b/AudioTagger.Tests/RegexTests.cs
@@ -7,9 +7,9 @@ using System.Text.RegularExpressions;
 
 namespace AudioTagger.Tests;
 
-public class RegexTests
+public sealed class RegexTests
 {
-    public class ParsedItem
+    public sealed class ParsedItem
     {
         /// <summary>
         /// The file name from which the other expected values while be parsed, as possible.
@@ -34,7 +34,7 @@ public class RegexTests
         #endregion
     }
 
-    private class TestDataSet : IEnumerable<object[]>
+    private sealed class TestDataSet : IEnumerable<object[]>
     {
         public IEnumerator<object[]> GetEnumerator()
         {

--- a/AudioTagger.Tests/RegexTests.cs
+++ b/AudioTagger.Tests/RegexTests.cs
@@ -437,7 +437,7 @@ public class RegexTests
     {
         var regexCollection = new RegexCollection("Regexes.txt");
 
-        var match = regexCollection.GetFirstFileMatch(expected.FileName);
+        var match = regexCollection.GetFirstMatch(expected.FileName);
 
         var matchedTags = match.Groups
                                .OfType<Group>()

--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ Explanation of options:
 - `titleReplacements`: Optional. Substrings in titles that will be ignored when searching for duplicate files. This allows pairs like "My Song" and "My Song (Single Version)" to be considered identical. Otherwise, they would be considered separate titles.
 - `renamePatterns`: Mandatory. When renaming files, they will be renamed according to the first such pattern that matches the populated tags in each file. For example, if a file contains only artist and title information, then it will be renamed per the third option above.
 - `regexPatterns`: Mandatory. When tagging files, these regexes are used to match against the filenames. When there is a match, then the appropriate ID3 tags are updated in the file.
-- `artistGenres`: Optional.
+- `artistGenres`: Auto-populated when the `-g` option is supplied.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ Below is a snippet that illustrates the supported nodes with some examples:
             "(?<artists>.+) - (?<title>.+?(?:\\.{3})?)(?: \\[(?<year>\\d{4})\\])?(?: \\{(?<genres>.+?)\\})?(?=\\.\\S{3,4}$)",
             "(?<title>.+?) ?(?:\\[(?<year>\\d{4})\\])? ?(?:\\{(?<genres>.+?)\\})?(?=\\.[^.]+$)"
         ]
-    }
+    },
+    "artistGenres": {}
 }
 ```
 
@@ -57,3 +58,4 @@ Explanation of options:
 - `titleReplacements`: Optional. Substrings in titles that will be ignored when searching for duplicate files. This allows pairs like "My Song" and "My Song (Single Version)" to be considered identical. Otherwise, they would be considered separate titles.
 - `renamePatterns`: Mandatory. When renaming files, they will be renamed according to the first such pattern that matches the populated tags in each file. For example, if a file contains only artist and title information, then it will be renamed per the third option above.
 - `regexPatterns`: Mandatory. When tagging files, these regexes are used to match against the filenames. When there is a match, then the appropriate ID3 tags are updated in the file.
+- `artistGenres`: Optional.


### PR DESCRIPTION
- Add `-g` field to add key-value pairs of artists to genres to the settings file.
- When updating tags without an explicitly defined genre, check the setting file and populate genre using artist genre data found there, if any.
- Other minor improvements, including #32 