### PR TITLE
Lock ID3 to version 2.3

### DIFF
--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -17,10 +17,6 @@ public static class Program
     {
         IPrinter printer = new SpectrePrinter();
 
-        // Force ID3 version 2.3
-        TagLib.Id3v2.Tag.DefaultVersion = 3;
-        TagLib.Id3v2.Tag.ForceDefaultVersion = true;
-
         try
         {
             Run(args, printer);
@@ -58,6 +54,10 @@ public static class Program
             printer.Error(settingsResult.Errors[0].Message);
             return;
         }
+
+        SettingsService.SetId3v2Version(
+            version: SettingsService.Id3v2Version.TwoPoint3,
+            forceAsDefault: true);
 
         Queue<string> argQueue = new(args.Select(a => a.Trim()));
 

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -43,17 +43,13 @@ public static class Program
             return;
         }
 
-        Settings settings;
-        var settingsResult = SettingsService.Read(printer, createFileIfMissing: false);
-        if (settingsResult.IsSuccess)
+        var readSettingsResult = SettingsService.Read(printer, createFileIfMissing: false);
+        if (readSettingsResult.IsFailed)
         {
-            settings = settingsResult.Value;
-        }
-        else
-        {
-            printer.Error(settingsResult.Errors[0].Message);
+            printer.Error(readSettingsResult.Errors[0].Message);
             return;
         }
+        Settings settings = readSettingsResult.Value;
 
         SettingsService.SetId3v2Version(
             version: SettingsService.Id3v2Version.TwoPoint3,

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -14,6 +14,10 @@ public static class Program
     {
         IPrinter printer = new SpectrePrinter();
 
+        // Force ID3 version 2.3
+        TagLib.Id3v2.Tag.DefaultVersion = 3;
+        TagLib.Id3v2.Tag.ForceDefaultVersion = true;
+
         if (args.Length == 0)
         {
             PrintInstructions(printer);

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -4,6 +4,7 @@ global using System.Collections.Generic;
 global using System.Collections.Immutable;
 global using System.IO;
 global using AudioTagger.Library.MediaFiles;
+global using AudioTagger.Library.Settings;
 using Spectre.Console;
 using System.Text.Json;
 
@@ -103,7 +104,7 @@ public static class Program
 
         if (!filesData.Any())
         {
-            printer.Error("No files found.");
+            printer.Print("No files found.");
             return;
         }
 

--- a/AudioTagger.Library/IPathOperation.cs
+++ b/AudioTagger.Library/IPathOperation.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using AudioTagger.Library.MediaFiles;
+using AudioTagger.Library.Settings;
 
 namespace AudioTagger;
 

--- a/AudioTagger.Library/Rename.cs
+++ b/AudioTagger.Library/Rename.cs
@@ -2,6 +2,7 @@ using System.IO;
 using System.Text;
 using System.Globalization;
 using AudioTagger.Library.MediaFiles;
+using AudioTagger.Library.Settings;
 
 namespace AudioTagger;
 

--- a/AudioTagger.Library/Settings.cs
+++ b/AudioTagger.Library/Settings.cs
@@ -36,6 +36,27 @@ public static class SettingsService
 {
     private const string _settingsFileName = "settings.json";
 
+    public enum Id3v2Version : byte
+    {
+        TwoPoint2 = 2,
+        TwoPoint3 = 3,
+        TwoPoint4 = 4,
+    }
+
+    /// <summary>
+    /// Lock the ID3v2.x version to a valid one and optionally force that version.
+    /// </summary>
+    /// <param name="version">The ID3 version 2 subversion to use.</param>
+    /// <param name="forceAsDefault">
+    ///     When true, forces the specified version when writing the file.
+    ///     When false, will defer to the version within the file, if any.
+    /// </param>
+    public static void SetId3v2Version(Id3v2Version version, bool forceAsDefault)
+    {
+        TagLib.Id3v2.Tag.DefaultVersion = (byte)version;
+        TagLib.Id3v2.Tag.ForceDefaultVersion = forceAsDefault;
+    }
+
     /// <summary>
     /// Creates the specified settings file if it is missing.
     /// Otherwise, does nothing.

--- a/AudioTagger.Library/Settings.cs
+++ b/AudioTagger.Library/Settings.cs
@@ -44,7 +44,7 @@ public static class SettingsService
     }
 
     /// <summary>
-    /// Lock the ID3v2.x version to a valid one and optionally force that version.
+    /// Locks the ID3v2.x version to a valid one and optionally forces that version.
     /// </summary>
     /// <param name="version">The ID3 version 2 subversion to use.</param>
     /// <param name="forceAsDefault">

--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace AudioTagger.Library.Settings;
+
+public sealed record Settings
+{
+    [JsonPropertyName("duplicates")]
+    public Duplicates Duplicates { get; set; } = new();
+
+    [JsonPropertyName("tagging")]
+    public Tagging? Tagging { get; set; }
+
+    [JsonPropertyName("renamePatterns")]
+    public ImmutableList<string>? RenamePatterns { get; set; }
+
+    [JsonPropertyName("artistGenres")]
+    public Dictionary<string, string>? ArtistGenres { get; set; } = new();
+}
+
+public sealed record Duplicates
+{
+    [JsonPropertyName("titleReplacements")]
+    public ImmutableList<string>? TitleReplacements { get; set; }
+}
+
+public sealed record Tagging
+{
+    [JsonPropertyName("regexPatterns")]
+    public ImmutableList<string>? RegexPatterns { get; set; }
+}

--- a/AudioTagger.Library/Settings/SettingsService.cs
+++ b/AudioTagger.Library/Settings/SettingsService.cs
@@ -1,41 +1,16 @@
 using System.IO;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using FluentResults;
 
-namespace AudioTagger;
-
-public sealed record Settings
-{
-    [JsonPropertyName("duplicates")]
-    public Duplicates Duplicates { get; set; } = new();
-
-    [JsonPropertyName("tagging")]
-    public Tagging? Tagging { get; set; }
-
-    [JsonPropertyName("renamePatterns")]
-    public ImmutableList<string>? RenamePatterns { get; set; }
-
-    [JsonPropertyName("artistGenres")]
-    public Dictionary<string, string>? ArtistGenres { get; set; } = new();
-}
-
-public sealed record Duplicates
-{
-    [JsonPropertyName("titleReplacements")]
-    public ImmutableList<string>? TitleReplacements { get; set; }
-}
-
-public sealed record Tagging
-{
-    [JsonPropertyName("regexPatterns")]
-    public ImmutableList<string>? RegexPatterns { get; set; }
-}
+namespace AudioTagger.Library.Settings;
 
 public static class SettingsService
 {
     private const string _settingsFileName = "settings.json";
 
+    /// <summary>
+    /// Subversions of ID3 version 2 (such as 2.3 or 2.4).
+    /// </summary>
     public enum Id3v2Version : byte
     {
         TwoPoint2 = 2,
@@ -61,7 +36,6 @@ public static class SettingsService
     /// Creates the specified settings file if it is missing.
     /// Otherwise, does nothing.
     /// </summary>
-    /// <param name="printer"></param>
     /// <returns>A bool indicating success or no action (true) or else failure (false).</returns>
     public static bool CreateIfMissing(IPrinter printer)
     {

--- a/AudioTagger.Library/UpdatableFields.cs
+++ b/AudioTagger.Library/UpdatableFields.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using System.Globalization;
 using AudioTagger.Library.MediaFiles;
+using AudioTagger.Library.Settings;
 
 namespace AudioTagger;
 


### PR DESCRIPTION
My Ruby tool seems to use ID3 version 2.4, which I suspect my Android phone does not handle fully. (See issue #26.) I found a solution that might enable forcing the version to 2.3.

Primary resource: https://github.com/mono/taglib-sharp/issues/183