### PR TITLE
Dupes show longest filename

### DIFF
--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -48,9 +48,10 @@ public sealed class SpectrePrinter : IPrinter
 
         lineParts.ToList().ForEach(p =>
         {
-            AnsiConsole.Markup(
-                new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString()
-            );
+            if (p.AddLineBreak)
+                AnsiConsole.MarkupLine(new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString());
+            else
+                AnsiConsole.Markup(new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString());
         });
 
         PrintEmptyLines(appendLines);

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -49,8 +49,8 @@ public sealed class SpectrePrinter : IPrinter
         lineParts.ToList().ForEach(p =>
         {
             AnsiConsole.Markup(
-                new LineSubString(p.Text, p.FgColor, p.BgColor)
-                    .GetSpectreString());
+                new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString()
+            );
         });
 
         PrintEmptyLines(appendLines);

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -56,10 +56,10 @@ public sealed class TagDuplicateFinder : IPathOperation
 
             foreach (MediaFile mediaFile in dupeGroup)
             {
-                var header = innerIndex == 0
+                string header = innerIndex == 0
                     ? groupIndex.ToString().PadLeft(groupIndexPadding) + groupIndexAppend
                     : new string(' ', groupIndexPadding + groupIndexAppend.Length);
-                var titleArtist = SummarizeArtistTitle(mediaFile);
+                string titleArtist = SummarizeArtistTitle(mediaFile);
                 var titleArtistFormatted = new LineSubString(header + titleArtist);
                 var separator = new LineSubString(new string(' ', longestTitleLength - titleArtist.Length + 1));
                 var metadata = new LineSubString(
@@ -68,7 +68,7 @@ public sealed class TagDuplicateFinder : IPathOperation
                     bgColor: null,
                     addLineBreak: true
                 );
-                printer.Print(new[] { titleArtistFormatted, separator, metadata });
+                printer.Print(new LineSubString[] { titleArtistFormatted, separator, metadata });
 
                 innerIndex++;
             }
@@ -98,6 +98,13 @@ public sealed class TagDuplicateFinder : IPathOperation
         }
     }
 
+    /// <summary>
+    /// Removes parts of a string that should be ignored for comparison.
+    /// For example, "The Beatles" would convert to "Beatles" because "The"
+    /// should not be included in the comparison.
+    /// </summary>
+    /// <param name="artists"></param>
+    /// <returns></returns>
     private static string ConcatenateArtistsForComparison(IEnumerable<string> artists)
     {
         return

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -43,6 +43,22 @@ public sealed class TagDuplicateFinder : IPathOperation
         PrintResults(duplicateGroups, printer);
     }
 
+    private static void PrintResults(IList<IGrouping<string, MediaFile>> duplicateGroups, IPrinter printer)
+    {
+        uint index = 0;
+        int indexPadding = duplicateGroups.Count.ToString().Length + 2;
+
+        foreach (var dupeGroup in duplicateGroups)
+        {
+            index++;
+            var firstDupe = dupeGroup.MaxBy(mediaFile => mediaFile.FileNameOnly.Length);
+            var artist = string.Concat(firstDupe!.Artists);
+            var title = firstDupe.Title;
+            var bitrate = "(" + string.Join(", ", dupeGroup.Select(d => d.BitRate + "kpbs")) + ")";
+            printer.Print($"{index.ToString().PadLeft(indexPadding)}. {artist} / {title}  {bitrate}");
+        }
+    }
+
     private static string ConcatenateArtists(IEnumerable<string> artists)
     {
         return
@@ -55,15 +71,14 @@ public sealed class TagDuplicateFinder : IPathOperation
     }
 
     /// <summary>
-    /// Remove specified text from a given string.
+    /// Removes each occurrence of text using a given collection of strings.
     /// </summary>
-    /// <param name="title"></param>
     /// <returns>The modified string.</returns>
     private static string RemoveUnneededText(string title, ImmutableList<string> terms)
     {
         return terms switch
         {
-            null => title,
+            null         => title,
             { Count: 0 } => title,
             _ => terms.ToList()
                       .Aggregate(
@@ -71,21 +86,5 @@ public sealed class TagDuplicateFinder : IPathOperation
                           (sb, term) => sb.Replace(term, string.Empty),
                           sb => sb.ToString().Trim())
         };
-    }
-
-    private static void PrintResults(IList<IGrouping<string, MediaFile>> duplicateGroups, IPrinter printer)
-    {
-        uint index = 0;
-        int indexPadding = duplicateGroups.Count.ToString().Length + 2;
-
-        foreach (var dupeGroup in duplicateGroups)
-        {
-            index++;
-            var firstDupe = dupeGroup.First();
-            var artist = string.Concat(firstDupe.Artists);
-            var title = firstDupe.Title;
-            var bitrate = "(" + string.Join(", ", dupeGroup.Select(d => d.BitRate + "kpbs")) + ")";
-            printer.Print($"{index.ToString().PadLeft(indexPadding)}. {artist} / {title}  {bitrate}");
-        }
     }
 }

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -92,7 +92,7 @@ public sealed class TagDuplicateFinder : IPathOperation
             var seconds = Math.Ceiling(mediaFile.Duration.TotalSeconds % 60);
             var time = $"{minutes}:{seconds:00}";
 
-            return $"({ext[1..]}; {bitrate}; {fileSize}; {time})";
+            return $"({ext[1..]}; {bitrate}; {time}; {fileSize})";
         }
     }
 

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -63,8 +63,10 @@ public sealed class TagDuplicateFinder : IPathOperation
                 var titleArtistFormatted = new LineSubString(header + titleArtist);
                 var separator = new LineSubString(new string(' ', longestTitleLength - titleArtist.Length + 1));
                 var metadata = new LineSubString(
-                    "  " + SummarizeMetadata(mediaFile) + Environment.NewLine, // TODO: Make the new line unnecessary.
-                    ConsoleColor.Cyan
+                    text: "  " + SummarizeMetadata(mediaFile),
+                    fgColor: ConsoleColor.Cyan,
+                    bgColor: null,
+                    addLineBreak: true
                 );
                 printer.Print(new[] { titleArtistFormatted, separator, metadata });
 

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -64,7 +64,7 @@ public sealed class TagDuplicateFinder : IPathOperation
                 var separator = new LineSubString(new string(' ', longestTitleLength - titleArtist.Length + 1));
                 var metadata = new LineSubString(
                     "  " + SummarizeMetadata(mediaFile) + Environment.NewLine, // TODO: Make the new line unnecessary.
-                    ConsoleColor.Gray // TODO: Figure out why this doesn't work.
+                    ConsoleColor.Cyan
                 );
                 printer.Print(new[] { titleArtistFormatted, separator, metadata });
 

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -61,12 +61,12 @@ public sealed class TagDuplicateFinder : IPathOperation
                     : new string(' ', groupIndexPadding + groupIndexAppend.Length);
                 var titleArtist = SummarizeArtistTitle(mediaFile);
                 var titleArtistFormatted = new LineSubString(header + titleArtist);
-                var separator = new LineSubString(new string(' ', longestTitleLength - titleArtist.Length));
+                var separator = new LineSubString(new string(' ', longestTitleLength - titleArtist.Length + 1));
                 var metadata = new LineSubString(
                     "  " + SummarizeMetadata(mediaFile) + Environment.NewLine, // TODO: Make the new line unnecessary.
                     ConsoleColor.Gray // TODO: Figure out why this doesn't work.
                 );
-                printer.Print(new[] { titleArtistFormatted, separator, metadata});
+                printer.Print(new[] { titleArtistFormatted, separator, metadata });
 
                 innerIndex++;
             }
@@ -79,7 +79,7 @@ public sealed class TagDuplicateFinder : IPathOperation
         {
             var artist = string.Join("; ", mediaFile.Artists);
             var title = mediaFile.Title;
-            return $"{artist} / {title}";
+            return $"{artist}  /  {title}";
         }
 
         static string SummarizeMetadata(MediaFile mediaFile)

--- a/AudioTagger.Library/LineSubstring.cs
+++ b/AudioTagger.Library/LineSubstring.cs
@@ -5,12 +5,18 @@ public sealed class LineSubString
     public string Text { get; set; }
     public ConsoleColor? FgColor { get; set; }
     public ConsoleColor? BgColor { get; set; }
+    public bool AddLineBreak { get; set; }
 
-    public LineSubString(string text, ConsoleColor? fgColor = null, ConsoleColor? bgColor = null)
+    public LineSubString(
+        string text,
+        ConsoleColor? fgColor = null,
+        ConsoleColor? bgColor = null,
+        bool addLineBreak = false)
     {
         Text = text;
         FgColor = fgColor;
         BgColor = bgColor;
+        AddLineBreak = addLineBreak;
     }
 
     public string GetSpectreString()

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -16,6 +16,8 @@ public sealed class MediaFile
 
     public string FileNameOnly => System.IO.Path.GetFileName(Path);
 
+    public long FileSizeInBytes => new System.IO.FileInfo(Path).Length;
+
     public string Title
     {
         get => _taggedFile.Tag.Title?.Normalize() ?? string.Empty;


### PR DESCRIPTION
When checking for duplicates, list all duplicate files. Also show more file metadata (adding duration and file size) and align it for easier viewing.