### PR TITLE
Add `HasText()` extension method

### DIFF
--- a/AudioTagger.Console/ExtensionMethods.cs
+++ b/AudioTagger.Console/ExtensionMethods.cs
@@ -1,0 +1,10 @@
+namespace AudioTagger.Console;
+
+public static class ExtensionMethods
+{
+    /// <summary>
+    /// Returns a bool indicating whether a string is not null and has text (true) or not.
+    /// </summary>
+    /// <remarks>I just got tired of `!string.IsNullOrWhiteSpace` everywhere...</remarks>
+    public static bool HasText(this string str) => !string.IsNullOrWhiteSpace(str);
+}

--- a/AudioTagger.Console/MediaFilePathInfo.cs
+++ b/AudioTagger.Console/MediaFilePathInfo.cs
@@ -21,7 +21,7 @@ internal sealed class MediaFilePathInfo
         string fileName)
     {
         WorkingPath = workingPath;
-        SubDirectories = subDirectories.Where(sd => !string.IsNullOrWhiteSpace(sd)).ToList();
+        SubDirectories = subDirectories.Where(sd => sd.HasText()).ToList();
         FileName = fileName;
     }
 

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -163,7 +163,7 @@ public sealed class MediaFileRenamer : IPathOperation
         string newArtistDir = useArtistFolder
             ? GenerateSafeDirectoryName(file)
             : string.Empty;
-        string newAlbumDir = useAlbumFolders && useArtistFolder && !string.IsNullOrWhiteSpace(file.Album)
+        string newAlbumDir = useAlbumFolders && useArtistFolder && file.Album.HasText()
             ? IOUtilities.SanitizePath(file.Album)
             : string.Empty;
         string newFileName = GenerateFileNameViaTagData(file, populatedTagNames, matchedRenamePattern);
@@ -278,7 +278,7 @@ public sealed class MediaFileRenamer : IPathOperation
             if (MediaFile.HasAnyValues(file.Artists))
                 return IOUtilities.SanitizePath(file.Artists);
 
-            if (!string.IsNullOrWhiteSpace(file.Album))
+            if (file.Album.HasText())
                 return IOUtilities.SanitizePath(file.Album);
 
             return "___UNSPECIFIED___";

--- a/AudioTagger.Console/MediaFileViewer.cs
+++ b/AudioTagger.Console/MediaFileViewer.cs
@@ -1,3 +1,4 @@
+using AudioTagger.Console;
 using Spectre.Console;
 
 namespace AudioTagger;
@@ -46,13 +47,13 @@ public sealed class MediaFileViewer
                 file.Composers.Join().EscapeMarkup());
         }
 
-        if (!string.IsNullOrWhiteSpace(file.Comments))
+        if (file.Comments.HasText())
             table.AddRow(tagNameFormatter("Comments"), file.Comments.EscapeMarkup());
 
-        if (!string.IsNullOrWhiteSpace(file.Description))
+        if (file.Description.HasText())
             table.AddRow(tagNameFormatter("Comments"), file.Description.EscapeMarkup());
 
-        if (!string.IsNullOrWhiteSpace(file.Lyrics))
+        if (file.Lyrics.HasText())
             table.AddRow(tagNameFormatter("Lyrics"), file.Lyrics[..25].EscapeMarkup() + "...");
 
         table.Columns[0].Width(15);

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -19,7 +19,7 @@ public sealed class TagDuplicateFinder : IPathOperation
         var duplicateGroups = mediaFiles
             .ToLookup(m => ConcatenateCollectionText(m.Artists) +
                            RemoveSubstrings(m.Title, titleReplacements))
-            .Where(m => !string.IsNullOrWhiteSpace(m.Key) && m.Count() > 1)
+            .Where(m => m.Key.HasText() && m.Count() > 1)
             .OrderBy(m => m.Key)
             .ToImmutableArray();
 

--- a/AudioTagger.Console/TagScanner.cs
+++ b/AudioTagger.Console/TagScanner.cs
@@ -33,7 +33,7 @@ public sealed class TagScanner : IPathOperation
             if (mp3.SampleRate >= 48_000)
             {
                 // Check for URLs in the comments.
-                if (!string.IsNullOrWhiteSpace(mp3.Comments) &&
+                if (mp3.Comments.HasText() &&
                     urlRegex.Match(mp3.Comments) is Match match &&
                     match.Success)
                 {

--- a/AudioTagger.Library/ExtensionMethods.cs
+++ b/AudioTagger.Library/ExtensionMethods.cs
@@ -1,0 +1,10 @@
+namespace AudioTagger.Library;
+
+public static class ExtensionMethods
+{
+    /// <summary>
+    /// Returns a bool indicating whether a string is not null and has text (true) or not.
+    /// </summary>
+    /// <remarks>I just got tired of `!string.IsNullOrWhiteSpace` everywhere...</remarks>
+    public static bool HasText(this string str) => !string.IsNullOrWhiteSpace(str);
+}

--- a/AudioTagger.Library/Genres/GenreService.cs
+++ b/AudioTagger.Library/Genres/GenreService.cs
@@ -18,7 +18,7 @@ public static class GenreService
         try
         {
             var lines = artistsWithGenres
-                .Where(ag => !string.IsNullOrWhiteSpace(ag.Key))
+                .Where(ag => ag.Key.HasText())
                 .OrderBy(ag => ag.Key)
                 .Select(ag => $"{ag.Key}{Delimiters[0]}{ag.Value}");
             File.WriteAllLines(genreFileName, lines);

--- a/AudioTagger.Library/IOUtilities.cs
+++ b/AudioTagger.Library/IOUtilities.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace AudioTagger;
+namespace AudioTagger.Library;
 
 public static class IOUtilities
 {
@@ -16,7 +16,7 @@ public static class IOUtilities
     public static readonly Func<string, bool> IsSupportedFileExtension =
         new(
             fileName =>
-                !string.IsNullOrWhiteSpace(fileName) &&
+                fileName.HasText() &&
                 !fileName.StartsWith(".") && // Unix-based OS hidden files
                 SupportedExtensions.Any(ext =>
                     fileName.EndsWith(ext, StringComparison.InvariantCultureIgnoreCase)));

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -31,7 +31,7 @@ public sealed class MediaFile
                 ?? Array.Empty<string>();
 
         set => _taggedFile.Tag.AlbumArtists =
-                    value.Where(a => !string.IsNullOrWhiteSpace(a))
+                    value.Where(a => a.HasText())
                          .Select(a => a.Trim().Normalize())
                          .Distinct()
                          .ToArray();
@@ -45,7 +45,7 @@ public sealed class MediaFile
                 ?? Array.Empty<string>();
 
         set => _taggedFile.Tag.Performers =
-                    value.Where(a => !string.IsNullOrWhiteSpace(a))
+                    value.Where(a => a.HasText())
                          .Select(a => a.Trim().Normalize())
                          .Distinct()
                          .ToArray();
@@ -224,9 +224,9 @@ public sealed class MediaFile
             tags.Add("ALBUMARTISTS");
         if (HasAnyValues(this.Artists))
             tags.Add("ARTISTS");
-        if (!string.IsNullOrWhiteSpace(this.Album))
+        if (this.Album.HasText())
             tags.Add("ALBUM");
-        if (!string.IsNullOrWhiteSpace(this.Title))
+        if (this.Title.HasText())
             tags.Add("TITLE");
         if (this.Year != 0)
             tags.Add("YEAR");

--- a/AudioTagger.Library/OutputLine.cs
+++ b/AudioTagger.Library/OutputLine.cs
@@ -1,3 +1,4 @@
+using AudioTagger.Library;
 using AudioTagger.Library.MediaFiles;
 
 namespace AudioTagger;
@@ -97,7 +98,7 @@ public sealed class OutputLine
         if (fileData.Composers?.Length > 0)
             lines.Add(TagDataWithHeader("Composers", fileData.Composers.Join()));
 
-        if (!string.IsNullOrWhiteSpace(fileData.Comments))
+        if (fileData.Comments.HasText())
             lines.Add(TagDataWithHeader("Comment", fileData.Comments));
 
         return lines;
@@ -132,7 +133,7 @@ public sealed class OutputLine
         if (fileData.Composers?.Length > 0)
             lines.Add("Composers", string.Join("; ", fileData.Composers));
 
-        if (includeComments && !string.IsNullOrWhiteSpace(fileData.Comments))
+        if (includeComments && fileData.Comments.HasText())
             lines.Add("Comment", fileData.Comments);
 
         return lines;

--- a/AudioTagger.Library/RegexCollection.cs
+++ b/AudioTagger.Library/RegexCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using AudioTagger.Library;
 
 namespace AudioTagger;
 
@@ -18,8 +19,8 @@ public sealed record class RegexCollection
 
         Patterns = regexes.Where(line =>
                                !line.StartsWith("# ") &&  // Comments
-                               !line.StartsWith("// ") &&  // Comments
-                               !string.IsNullOrWhiteSpace(line))
+                               !line.StartsWith("// ") && // Comments
+                               line.HasText())
                           .Distinct()
                           .ToList();
     }


### PR DESCRIPTION
I got tired of using `!string.IsNullOrWhiteSpace()` so much, so I created a tiny extension method called `HasText()` for it.