### PR TITLE
Allow user to specify save directory for duplicates playlist

### DIFF
--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -30,6 +30,9 @@ public sealed record Duplicates
 
     [JsonPropertyName("pathReplaceWith")]
     public string? PathReplaceWith { get; set; }
+
+    [JsonPropertyName("savePlaylistDirectory")]
+    public string? SavePlaylistDirectory { get; set; }
 }
 
 public sealed record Tagging


### PR DESCRIPTION
- [x] Allow users to specify, in their settings file, a save-to directory for duplicates playlists, using the application directory as a default