### PR TITLE
List and read audio files in separate steps

### DIFF
--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -1,6 +1,5 @@
 ﻿using AudioTagger.Library;
 using Spectre.Console;
-using System.Text.Json;
 
 namespace AudioTagger.Console;
 
@@ -13,14 +12,6 @@ public static class Program
         try
         {
             Run(args, printer);
-        }
-        catch (FileNotFoundException ex)
-        {
-            printer.Error($"Missing file error: {ex.Message}");
-        }
-        catch (JsonException ex)
-        {
-            printer.Error($"JSON error: {ex.Message}");
         }
         catch (Exception ex)
         {
@@ -45,6 +36,7 @@ public static class Program
         }
         Settings settings = readSettingsResult.Value;
 
+        // Prefer ID3 v2.3 over v2.4 because the former is apparently more widely supported.
         SettingsService.SetId3v2Version(
             version: SettingsService.Id3v2Version.TwoPoint3,
             forceAsDefault: true);

--- a/AudioTagger.Library/IOUtilities.cs
+++ b/AudioTagger.Library/IOUtilities.cs
@@ -61,9 +61,10 @@ public static class IOUtilities
     /// <remarks>It might be nice to allow specifying custom replacements for each invalid character.</remarks>
     public static string SanitizePath(string path, char replacementChar = '_')
     {
-        IEnumerable<char> invalidChars = System.IO.Path.GetInvalidPathChars()
-                                .Concat(System.IO.Path.GetInvalidFileNameChars())
-                                .Concat(UnsafePathChars);
+        IEnumerable<char> invalidChars =
+            System.IO.Path.GetInvalidPathChars()
+                .Concat(System.IO.Path.GetInvalidFileNameChars())
+                .Concat(UnsafePathChars);
 
         return invalidChars
                     .Aggregate(


### PR DESCRIPTION
Until now, I was listing all files in a path and populating the files' tags in a single method, giving it too many responsibilities, so I've extracted the former step to another method in the `IOUtilities` library class.

This allows the program display separate times for listing files and populating their tags.