### PR TITLE
Rename `JoinPrimaryWithSecondary()` extension method

### DIFF
--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -111,18 +111,20 @@ public static class Program
         }
         printer.Print($"Found {fileNames.Length:#,##0} files in {watch.ElapsedFriendly}.");
 
-        var populateResult = MediaFile.PopulateFileData(fileNameResult.Value);
+        var populateResult = MediaFile.PopulateTagData(fileNameResult.Value);
         if (populateResult.IsFailed)
         {
             printer.Error($"No file tags were successfully read.");
             populateResult.Errors.Take(5).ToList().ForEach(e => printer.Error(e.Message));
             if (populateResult.Errors.Count > 5)
+            {
                 printer.Error($"plus {populateResult.Errors.Count - 5} more errors...");
+            }
             return;
         }
 
         var (mediaFiles, errors) = populateResult.Value;
-        if (errors.Any())
+        if (errors.Count != 0)
         {
             printer.Warning($"There were {errors.Count} error(s) reading file tags.");
         }

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -106,7 +106,7 @@ public static class Program
         var fileNames = fileNameResult.Value;
         if (fileNames.IsEmpty)
         {
-            printer.Error("No files were found, so will skip this path.");
+            printer.Warning("No files were found in \"{path}\".");
             return;
         }
         printer.Print($"Found {fileNames.Length:#,##0} files in {watch.ElapsedFriendly}.");

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -176,7 +176,7 @@ public sealed class MediaFile
     /// </summary>
     /// <param name="filePaths">A collection of files.</param>
     /// <returns>A collection of `MediaFile` representing tagged audio files.</returns>
-    public static Result<(ImmutableList<MediaFile>, List<string>)> PopulateFileData(IEnumerable<string> filePaths)
+    public static Result<(ImmutableList<MediaFile>, List<string>)> PopulateTagData(IEnumerable<string> filePaths)
     {
        var mediaFiles = new List<MediaFile>();
        var errors = new List<string>();

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -56,7 +56,7 @@ public sealed class MediaFile
     /// <summary>
     /// A summary of both album artists and/or track artists; otherwise, an empty string.
     /// </summary>
-    public string ArtistSummary => AlbumArtists.JoinPrimaryWithSecondary(Artists, "; ");
+    public string ArtistSummary => AlbumArtists.JoinWith(Artists, "; ");
 
     public string Album
     {

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -176,9 +176,9 @@ public sealed class MediaFile
     /// </summary>
     /// <param name="filePaths">A collection of files.</param>
     /// <returns>A collection of `MediaFile` representing tagged audio files.</returns>
-    public static Result<(ImmutableList<MediaFile>, List<string>)> PopulateTagData(IEnumerable<string> filePaths)
+    public static Result<(ImmutableList<MediaFile>, List<string>)> PopulateTagData(ICollection<string> filePaths)
     {
-       var mediaFiles = new List<MediaFile>();
+       var mediaFiles = new List<MediaFile>(filePaths.Count);
        var errors = new List<string>();
 
         foreach (string fileName in filePaths)

--- a/AudioTagger.Library/MediaFiles/MediaFileExtensionMethods.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFileExtensionMethods.cs
@@ -43,22 +43,28 @@ public static class MediaFileExtensionMethods
     }
 
     /// <summary>
-    /// Combines two string collections, enclosing the secondary one in parentheses if both are present.
+    /// Combines two string collections to a string representation.
+    /// If they are identical or if only one collection has items,
+    /// only one will be included, as-is. If both have differing items,
+    /// then both will be included, with the secondary collection's
+    /// items will be enclosed in parentheses.
     /// </summary>
-    public static string JoinPrimaryWithSecondary(
+    public static string JoinWith(
         this IList<string> primary,
         IList<string> secondary,
         string separator)
     {
-        static string formatter(IList<string> artists, string separator) => string.Join(separator, artists);
+        static string Format(IList<string> artists, string separator) =>
+            string.Join(separator, artists);
 
         return (primary, secondary) switch
         {
-            ([..], [])   => $"{formatter(primary, separator)}",
-            ([], [..])   => $"{formatter(secondary, separator)}",
-            ([..], [..]) when primary.All(secondary.Contains) && primary.Count == secondary.Count
-                         => $"{formatter(primary, separator)}",
-            ([..], [..]) => $"{formatter(primary, separator)} ({formatter(secondary, separator)})",
+            ([..], [])   => $"{Format(primary, separator)}",
+            ([], [..])   => $"{Format(secondary, separator)}",
+            ([..], [..]) when primary.All(secondary.Contains)
+                           && primary.Count == secondary.Count
+                         => $"{Format(primary, separator)}",
+            ([..], [..]) => $"{Format(primary, separator)} ({Format(secondary, separator)})",
             _ => string.Empty,
         };
     }

--- a/AudioTagger.Tests/MediaFileTests.cs
+++ b/AudioTagger.Tests/MediaFileTests.cs
@@ -15,7 +15,7 @@ public sealed class MediaFileTests
             string[] albumArtists = ["Album Artist A"];
             string[] artists = ["Artist 1", "Artist 2"];
             string expected = "Album Artist A (Artist 1; Artist 2)";
-            string actual = albumArtists.JoinPrimaryWithSecondary(artists, Separator);
+            string actual = albumArtists.JoinWith(artists, Separator);
             Assert.Equal(expected, actual);
         }
 
@@ -25,7 +25,7 @@ public sealed class MediaFileTests
             string[] albumArtists = ["Album Artist"];
             string[] artists = [];
             string expected = "Album Artist";
-            string actual = albumArtists.JoinPrimaryWithSecondary(artists, Separator);
+            string actual = albumArtists.JoinWith(artists, Separator);
             Assert.Equal(expected, actual);
         }
 
@@ -35,7 +35,7 @@ public sealed class MediaFileTests
             string[] albumArtists = [];
             string[] artists = ["Artist 1", "Artist 2"];
             string expected = "Artist 1; Artist 2";
-            string actual = albumArtists.JoinPrimaryWithSecondary(artists, Separator);
+            string actual = albumArtists.JoinWith(artists, Separator);
             Assert.Equal(expected, actual);
         }
 
@@ -45,7 +45,7 @@ public sealed class MediaFileTests
             string[] albumArtists = [];
             string[] artists = [];
             string expected = string.Empty;
-            string actual = albumArtists.JoinPrimaryWithSecondary(artists, Separator);
+            string actual = albumArtists.JoinWith(artists, Separator);
             Assert.Equal(expected, actual);
         }
 
@@ -55,7 +55,7 @@ public sealed class MediaFileTests
             string[]? albumArtists = null;
             string[]? artists = null;
             string expected = string.Empty;
-            string actual = albumArtists!.JoinPrimaryWithSecondary(artists!, Separator);
+            string actual = albumArtists!.JoinWith(artists!, Separator);
             Assert.Equal(expected, actual);
         }
     }


### PR DESCRIPTION
- Rename the `JoinPrimaryWithSecondary()` extension method
- Improve its comments
- Other minor improvements