### PR TITLE
Show progress of reading files' tags

### DIFF
--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -114,15 +114,18 @@ public static class Program
         List<string> errors = [];
         List<MediaFile> mediaFiles = [];
         AnsiConsole.Progress()
+            .AutoClear(true)
+            .Columns(new ProgressColumn[]
+            {
+                new TaskDescriptionColumn(),
+                new ProgressBarColumn(),
+                new PercentageColumn(),
+                new RemainingTimeColumn(),
+                new SpinnerColumn(),
+            })
             .Start(ctx =>
             {
-                // var batches = fileNames.Chunk(10);
-                // var iterateBy = 100 / fileNames.Length;
-                var task = ctx.AddTask("[green]Populating file tags[/]", maxValue: fileNames.Length);
-
-                // while(!ctx.IsFinished)
-                // {
-                // }
+                var task = ctx.AddTask("Populating file tags", maxValue: fileNames.Length);
 
                 foreach (var fileName in fileNames)
                 {
@@ -139,7 +142,6 @@ public static class Program
                     task.Increment(1);
                 }
             });
-
 
         nint successes = fileNames.Length - errors.Count;
         printer.Print($"Tags of {successes:#,##0} files read in {watch.ElapsedFriendly}.");

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -99,11 +99,12 @@ public static class Program
         var fileNameResult = IOUtilities.GetAllFileNames(path, searchSubDirectories: true);
         if (fileNameResult.IsFailed)
         {
-            printer.Error($"Could not read filenames for path \"{path}\"");
+            var firstMessage = fileNameResult.Errors.First().Message;
+            printer.Error($"Could not read any filenames for path \"{path}\": {firstMessage}");
             return;
         }
 
-        var fileNames = fileNameResult.Value;
+        ImmutableArray<string> fileNames = fileNameResult.Value;
         if (fileNames.IsEmpty)
         {
             printer.Warning("No files were found, so will skip this path.");
@@ -120,6 +121,7 @@ public static class Program
         if (tagReadErrors.Count != 0)
         {
             printer.Warning($"Tags could not be read for {tagReadErrors.Count} file(s).");
+
             int showCount = 10;
             tagReadErrors.Take(showCount).ToList().ForEach(printer.Error);
             if (tagReadErrors.Count > showCount)
@@ -132,7 +134,7 @@ public static class Program
         }
         catch (Exception ex)
         {
-            printer.Error($"Error in main operation: {ex.Message}");
+            printer.Error($"Error in while processing path \"{path}\": {ex.Message}");
             printer.PrintException(ex);
             return;
         }

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -203,6 +203,19 @@ public sealed class MediaFile
         return Result.Fail(errors);
     }
 
+    public static Result<MediaFile> PopulateSingleFileData(string filePath)
+    {
+        try
+        {
+            MediaFile mediaFile = MediaFileFactory.CreateFileData(filePath);
+            return Result.Ok(mediaFile);
+        }
+        catch (Exception)
+        {
+            return Result.Fail($"Could not read metadata of file \"{filePath}\"");
+        }
+    }
+
     /// <summary>
     /// Generates and returns a list of tags that are populated in the file.
     /// </summary>

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -170,39 +170,8 @@ public sealed class MediaFile
     }
 
     /// <summary>
-    /// Given a folder or file path, returns a list of AudioFile for each file.
-    /// Thus, a path to a file will always return a collection of one item,
-    /// and a path to a folder will return an AudioFile for each file within that folder.
+    /// Given a file path, returns the tag information from that file.
     /// </summary>
-    /// <param name="filePaths">A collection of files.</param>
-    /// <returns>A collection of `MediaFile` representing tagged audio files.</returns>
-    public static Result<(ImmutableList<MediaFile>, List<string>)> PopulateFileData(IEnumerable<string> filePaths)
-    {
-       var mediaFiles = new List<MediaFile>();
-       var errors = new List<string>();
-
-        foreach (string fileName in filePaths)
-        {
-            try
-            {
-                mediaFiles.Add(MediaFileFactory.CreateFileData(fileName));
-            }
-            catch (Exception)
-            {
-                errors.Add($"Could not read metadata of file \"{fileName}\"");
-            }
-        }
-
-        if (mediaFiles.Count != 0)
-        {
-            var orderedFiles = mediaFiles.OrderBy(f => f.Path)
-                                         .ToImmutableList();
-            return Result.Ok((orderedFiles, errors));
-        }
-
-        return Result.Fail(errors);
-    }
-
     public static Result<MediaFile> ReadFileTags(string filePath)
     {
         try
@@ -217,7 +186,7 @@ public sealed class MediaFile
     }
 
     /// <summary>
-    /// Generates and returns a list of tags that are populated in the file.
+    /// Generates and returns a list of tag frames in the file that are populated.
     /// </summary>
     public ImmutableList<string> PopulatedTagNames()
     {
@@ -236,7 +205,7 @@ public sealed class MediaFile
         if (this.TrackNo != 0)
             tags.Add("TRACK");
 
-        return tags.ToImmutableList();
+        return [.. tags];
     }
 
     /// <summary>

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -203,16 +203,16 @@ public sealed class MediaFile
         return Result.Fail(errors);
     }
 
-    public static Result<MediaFile> PopulateSingleFileData(string filePath)
+    public static Result<MediaFile> ReadFileTags(string filePath)
     {
         try
         {
             MediaFile mediaFile = MediaFileFactory.CreateFileData(filePath);
             return Result.Ok(mediaFile);
         }
-        catch (Exception)
+        catch (Exception ex)
         {
-            return Result.Fail($"Could not read metadata of file \"{filePath}\"");
+            return Result.Fail($"Could not read tags of file \"{filePath}\": {ex.Message}");
         }
     }
 


### PR DESCRIPTION
- What: Show the progress of reading tags from files. 
- Why: Loading tags from many files on certain drives can take a very long time, so let's give the user some indication of progress and remaining time.
- How: Leveraging more of Spectre.Console.