### PR TITLE
Allow exclusion of specific subdirectories from renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.profraw
 .DS_Store
-settings.json
+settings*.json
 input.txt
 *.log
 *.csv

--- a/AudioTagger.Console/ExtensionMethods.cs
+++ b/AudioTagger.Console/ExtensionMethods.cs
@@ -14,4 +14,11 @@ public static class ExtensionMethods
             null or { Length: 0 } => null,
             _ => text
         };
+
+    /// <summary>
+    /// Parses a complete file path, returning the file's parent directory name.
+    /// Example: "/me/Documents/audio/123.m4a" returns "audio".
+    /// </summary>
+    public static string? FileParentDirectory(this string fileName) =>
+        Path.GetFileName(Path.GetDirectoryName(fileName) ?? null);
 }

--- a/AudioTagger.Console/Extensions.cs
+++ b/AudioTagger.Console/Extensions.cs
@@ -1,6 +1,6 @@
 namespace AudioTagger.Console;
 
-public static class ExtensionMethods
+public static class Extensions
 {
     /// <summary>
     /// Returns a bool indicating whether a string is not null and has text (true) or not.
@@ -14,11 +14,4 @@ public static class ExtensionMethods
             null or { Length: 0 } => null,
             _ => text
         };
-
-    /// <summary>
-    /// Parses a complete file path, returning the file's parent directory name.
-    /// Example: "/me/Documents/audio/123.m4a" returns "audio".
-    /// </summary>
-    public static string? FileParentDirectory(this string fileName) =>
-        Path.GetFileName(Path.GetDirectoryName(fileName) ?? null);
 }

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -46,9 +46,15 @@ public sealed class MediaFileRenamer : IPathOperation
             return;
         }
 
-        if (mediaFiles.Count != eligibleMediaFiles.Count)
+        if (mediaFiles.Count == eligibleMediaFiles.Count)
         {
-            printer.Print($"Out of {mediaFiles.Count} files, {eligibleMediaFiles.Count} are eligible for renaming.");
+            printer.Print("All files are eligible for renaming.");
+        }
+        else
+        {
+            var diff = mediaFiles.Count - eligibleMediaFiles.Count;
+            var isAre = diff == 1 ? "is" : "are";
+            printer.Print($"Out of {mediaFiles.Count} files, {diff} {isAre} eligible for renaming.");
         }
 
         if (!ConfirmStart(workingDirectory, printer))
@@ -176,7 +182,6 @@ public sealed class MediaFileRenamer : IPathOperation
     {
         ArgumentNullException.ThrowIfNull(file);
 
-        // TODO: Refactor cancellation so this isn't needed.
         const bool shouldCancel = false;
 
         var populatedTagNames = file.PopulatedTagNames();

--- a/AudioTagger.Console/MediaFileRenamer.cs
+++ b/AudioTagger.Console/MediaFileRenamer.cs
@@ -30,13 +30,10 @@ public sealed class MediaFileRenamer : IPathOperation
 
         printer.Print($"Found {settings.Renaming.Patterns.Count} rename patterns.");
 
-        static bool IsEligibleForRename(ImmutableList<string> ignoredDirectories, MediaFile file) =>
-            !ignoredDirectories.Contains(file.ParentDirectoryName);
-
         var eligibleMediaFiles = settings.Renaming.IgnoredDirectories is null
             ? mediaFiles
             : mediaFiles
-                .Where(file => IsEligibleForRename(settings.Renaming.IgnoredDirectories, file))
+                .Where(file => !settings.Renaming.IgnoredDirectories.Contains(file.ParentDirectoryName))
                 .ToList()
                 .AsReadOnly();
 
@@ -54,7 +51,7 @@ public sealed class MediaFileRenamer : IPathOperation
         {
             var diff = mediaFiles.Count - eligibleMediaFiles.Count;
             var isAre = diff == 1 ? "is" : "are";
-            printer.Print($"Out of {mediaFiles.Count} files, {diff} {isAre} eligible for renaming.");
+            printer.Print($"Out of {mediaFiles.Count} files, {diff} {isAre} ineligible for renaming.");
         }
 
         if (!ConfirmStart(workingDirectory, printer))

--- a/AudioTagger.Console/Normalization.cs
+++ b/AudioTagger.Console/Normalization.cs
@@ -22,12 +22,12 @@ public sealed class Normalization : IPathOperation
 
         foreach (MediaFile file in mediaFiles)
         {
-            printer.Print($"- {file.Path}");
+            printer.Print($"- {file.FileInfo}");
 
             ProcessStartInfo startInfo = new()
             {
                 FileName = "mp3gain",
-                Arguments = $"-r -k -p -s i \"{file.Path}\"",
+                Arguments = $"-r -k -p -s i \"{file.FileInfo}\"",
                 RedirectStandardOutput = true,
             };
 

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -83,7 +83,7 @@ public sealed class TagDuplicateFinder : IPathOperation
 
         static string SummarizeMetadata(MediaFile mediaFile)
         {
-            string ext = Path.GetExtension(mediaFile.Path).ToUpperInvariant();
+            string ext = Path.GetExtension(mediaFile.FileInfo.FullName).ToUpperInvariant();
             string bitrate = mediaFile.BitRate + " kpbs";
             string fileSize = mediaFile.FileSizeInBytes.ToString("#,##0") + " bytes";
 
@@ -165,8 +165,8 @@ public sealed class TagDuplicateFinder : IPathOperation
 
                 string updatedPath = replacements.SearchFor is null ||
                                      replacements.ReplaceWith is null
-                    ? m.Path
-                    : m.Path.Replace(replacements.SearchFor, replacements.ReplaceWith);
+                    ? m.FileInfo.FullName
+                    : m.FileInfo.FullName.Replace(replacements.SearchFor, replacements.ReplaceWith);
 
                 contents.AppendLine(updatedPath);
             });

--- a/AudioTagger.Console/TagScanner.cs
+++ b/AudioTagger.Console/TagScanner.cs
@@ -33,17 +33,17 @@ public sealed class TagScanner : IPathOperation
                     playlistUrlRegex.Match(file.Comments) is Match playlistMatch &&
                     playlistMatch.Success)
                 {
-                    highSampleRateWithPlaylistUrl.AppendLine($"{playlistMatch.Value};{file.Path}");
+                    highSampleRateWithPlaylistUrl.AppendLine($"{playlistMatch.Value};{file.FileInfo}");
                 }
                 else if (file.Comments.HasText() &&
                          videoUrlRegex.Match(file.Comments) is Match videoMatch &&
                          videoMatch.Success)
                 {
-                    highSampleRateWithVideoUrl.AppendLine($"{videoMatch.Value};{file.Path}");
+                    highSampleRateWithVideoUrl.AppendLine($"{videoMatch.Value};{file.FileInfo}");
                 }
                 else
                 {
-                    highSampleRateNoUrl.AppendLine($"{string.Join(", ", file.Artists)}; {file.Album}; {file.Title}; {file.Path}");
+                    highSampleRateNoUrl.AppendLine($"{string.Join(", ", file.Artists)}; {file.Album}; {file.Title}; {file.FileInfo}");
                 }
             }
             else if (file.BitRate < 110)
@@ -52,17 +52,17 @@ public sealed class TagScanner : IPathOperation
                     playlistUrlRegex.Match(file.Comments) is Match playlistMatch &&
                     playlistMatch.Success)
                 {
-                    lowBitRateWithPlaylistUrl.AppendLine($"{playlistMatch.Value};{file.Path}");
+                    lowBitRateWithPlaylistUrl.AppendLine($"{playlistMatch.Value};{file.FileInfo}");
                 }
                 else if (file.Comments.HasText() &&
                          videoUrlRegex.Match(file.Comments) is Match videoMatch &&
                          videoMatch.Success)
                 {
-                    lowBitRateWithVideoUrl.AppendLine($"{videoMatch.Value};{file.Path}");
+                    lowBitRateWithVideoUrl.AppendLine($"{videoMatch.Value};{file.FileInfo}");
                 }
                 else
                 {
-                    lowBitRateNoUrl.AppendLine($"{string.Join(", ", file.Artists)}; {file.Album}; {file.Title}; {file.Path}");
+                    lowBitRateNoUrl.AppendLine($"{string.Join(", ", file.Artists)}; {file.Album}; {file.Title}; {file.FileInfo}");
                 }
             }
             else

--- a/AudioTagger.Console/TagUpdaterMultiple.cs
+++ b/AudioTagger.Console/TagUpdaterMultiple.cs
@@ -20,7 +20,7 @@ public sealed class TagUpdaterMultiple : IPathOperation
                                          .ToList();
 
         printer.Print($"Will update the title tag of {sortedMediaFiles.Count} file(s):");
-        sortedMediaFiles.ForEach(f => printer.Print($"- {f.Path}"));
+        sortedMediaFiles.ForEach(f => printer.Print($"- {f.FileInfo}"));
 
         string[] inputLines;
         try
@@ -83,12 +83,12 @@ public sealed class TagUpdaterMultiple : IPathOperation
             catch (FormatException ex)
             {
                 failureCount++;
-                printer.Error($"{ex.Message} ({pair.File.Path})");
+                printer.Error($"{ex.Message} ({pair.File.FileInfo})");
             }
             catch (Exception ex)
             {
                 failureCount++;
-                printer.Error($"Error for \"{pair.File.Path}\": {ex.Message}");
+                printer.Error($"Error for \"{pair.File.FileInfo}\": {ex.Message}");
             }
         }
 

--- a/AudioTagger.Console/TagUpdaterReverseTrackNumbers.cs
+++ b/AudioTagger.Console/TagUpdaterReverseTrackNumbers.cs
@@ -22,7 +22,7 @@ public sealed class TagUpdaterReverseTrackNumbers : IPathOperation
                                     .ToList();
 
         printer.Print($"Will update the track number tag of {sortedFiles.Count} file(s):");
-        sortedFiles.ForEach(f => printer.Print($"- {f.Path}"));
+        sortedFiles.ForEach(f => printer.Print($"- {f.FileInfo}"));
 
         var reversedTrackNos = sortedFiles.Select(f => f.TrackNo).Reverse().ToImmutableList();
         var filesWithNewTrackNos = sortedFiles.Zip(reversedTrackNos,
@@ -61,7 +61,7 @@ public sealed class TagUpdaterReverseTrackNumbers : IPathOperation
             catch (Exception ex)
             {
                 failureCount++;
-                printer.Error($"Error for \"{pair.File.Path}\": {ex.Message}");
+                printer.Error($"Error for \"{pair.File.FileInfo}\": {ex.Message}");
             }
         }
 

--- a/AudioTagger.Console/TagUpdaterSingle.cs
+++ b/AudioTagger.Console/TagUpdaterSingle.cs
@@ -16,7 +16,7 @@ public sealed class TagUpdaterSingle : IPathOperation
     {
         printer.Print($"Will update a single tag in {mediaFiles.Count} files:");
         foreach (MediaFile file in mediaFiles)
-            printer.Print($"- {file.Path}");
+            printer.Print($"- {file.FileInfo}");
 
         string tagName = ConfirmUpdateTagName();
         TagUpdateType updateType = ConfirmUpdateType(tagName);
@@ -49,12 +49,12 @@ public sealed class TagUpdaterSingle : IPathOperation
             catch (FormatException ex)
             {
                 failureCount++;
-                printer.Error($"{ex.Message} ({file.Path})");
+                printer.Error($"{ex.Message} ({file.FileInfo})");
             }
             catch (Exception ex)
             {
                 failureCount++;
-                printer.Error($"Error for \"{file.Path}\": {ex.Message}");
+                printer.Error($"Error for \"{file.FileInfo}\": {ex.Message}");
             }
         }
 

--- a/AudioTagger.Console/TagUpdaterYearOnly.cs
+++ b/AudioTagger.Console/TagUpdaterYearOnly.cs
@@ -48,10 +48,8 @@ public sealed class TagUpdaterYearOnly : IPathOperation
         const bool shouldCancel = false;
         const string updateType = "year";
 
-        DateTime createdDt = System.IO.File.GetCreationTime(mediaFile.Path);
-
-        UpdatableFields updateableFields = new UpdatableFields(updateType, createdDt.Year);
-
+        var createdYear = mediaFile.FileInfo.CreationTime.Year;
+        var updateableFields = new UpdatableFields(updateType, createdYear);
         var proposedUpdates = updateableFields.GetUpdateKeyValuePairs(mediaFile);
 
         if (proposedUpdates?.Any() != true)

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -1,10 +1,11 @@
-﻿using FluentResults;
+﻿using System.IO;
+using FluentResults;
 
 namespace AudioTagger.Library.MediaFiles;
 
 public sealed class MediaFile
 {
-    public string Path { get; }
+    public FileInfo FileInfo { get; }
     private readonly TagLib.File _taggedFile;
 
     public MediaFile(string filePath, TagLib.File tabLibFile)
@@ -12,13 +13,16 @@ public sealed class MediaFile
         ArgumentNullException.ThrowIfNull(filePath);
         ArgumentNullException.ThrowIfNull(tabLibFile);
 
-        Path = filePath;
+        FileInfo = new FileInfo(filePath);
         _taggedFile = tabLibFile;
     }
 
-    public string FileNameOnly => System.IO.Path.GetFileName(Path);
+    public string FileNameOnly => FileInfo.Name;
 
-    public long FileSizeInBytes => new System.IO.FileInfo(Path).Length;
+    public long FileSizeInBytes => FileInfo.Length;
+
+    public string ParentDirectoryName => FileInfo.Directory!.Name;
+
 
     public string Title
     {

--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -10,14 +10,11 @@ public sealed record Settings
     [JsonPropertyName("tagging")]
     public Tagging? Tagging { get; set; }
 
-    [JsonPropertyName("renamePatterns")]
-    public ImmutableList<string>? RenamePatterns { get; set; }
+    [JsonPropertyName("renaming")]
+    public Renaming? Renaming { get; set; }
 
     [JsonPropertyName("artistGenreCsvFilePath")]
     public string? ArtistGenreCsvFilePath { get; set; } = null;
-
-    [JsonPropertyName("renameUseAlbumFolders")]
-    public bool RenameUseAlbumFolders { get; set; } = false;
 
     [JsonPropertyName("resetSavedArtistGenres")]
     public bool ResetSavedArtistGenres { get; set; } = false;
@@ -42,4 +39,16 @@ public sealed record Tagging
 {
     [JsonPropertyName("regexPatterns")]
     public ImmutableList<string>? RegexPatterns { get; set; }
+}
+
+public sealed record Renaming
+{
+    [JsonPropertyName("patterns")]
+    public ImmutableList<string>? Patterns { get; set; }
+
+    [JsonPropertyName("useAlbumDirectories")]
+    public bool UseAlbumDirectories { get; set; } = false;
+
+    [JsonPropertyName("ignoredDirectories")]
+    public ImmutableList<string>? IgnoredDirectories { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A .NET CLI program that can perform the following actions on audio files:
 
-- View ID3v2 tags
+- View ID3v2.3 tags
 - Auto-update tags using filename patterns
 - Update a single tag for multiple files at once
 - Auto-rename and reorganize files using filename patterns
@@ -12,7 +12,7 @@ A .NET CLI program that can perform the following actions on audio files:
 - See folder stats
 - Apply audio normalization (ReplayGain)
 
-This is a little labor-of-love project that I work on in my spare time. It's not particularly polished, but it's sufficient for my use case. It relies on the [TagLibSharp](https://github.com/mono/taglib-sharp) library for tag reading and writing.
+This is a little labor-of-love project that I work on in my spare time. It relies on the [TagLibSharp](https://github.com/mono/taglib-sharp) library for tag reading and writing.
 
 ## Requirements
 
@@ -20,39 +20,70 @@ This is a little labor-of-love project that I work on in my spare time. It's not
 
 ## Running
 
-Currently, you must run this app from the `AudioTagger.Console` folder using `dotnet run`. Passing no arguments will show the instructions.
+Run this app from the `AudioTagger.Console` folder using `dotnet run`. Passing no arguments will show the instructions.
 
 Additionally, `settings.json` should exist in the application directory for some features. A sparsely populated file will be automatically created if it does not already exist when the program is started.
 
-Below is a snippet that illustrates the supported nodes with some examples:
+A sample settings file follows:
 
 ```json
 {
-    "duplicates": {
-        "titleReplacements": [
-            "Single Version",
-            "Single Ver.",
-            "Single Ver",
-            "()",
-            "（）",
-            "•",
-            "・"
-        ]
-    },
-    "renamePatterns": [
-        "%ARTISTS% - %ALBUM% - %TRACK% - %TITLE%",
-        "%ARTISTS% - %TITLE% [%YEAR%]",
-        "%ARTISTS% - %TITLE%",
-        "%TITLE%"
+  "artistGenreCsvFilePath": "/Users/me/Documents/audio",
+  "resetSavedArtistGenres": true,
+  "renaming": {
+    "useAlbumDirectories": true,
+    "ignoredDirectories": [
+      "Directory 1",
+      "Directory 2"
     ],
-    "tagging": {
-        "regexPatterns": [
-            "(?<artists>.+) - (?<album>.+) - (?<title>.+?(?:\\.{3})?) ?(?:\\[(?<year>\\d{4})\\])? ?(?:\\{(?<genres>.+?)\\})?(?=\\..+)",
-            "(?<artists>.+) - (?<title>.+?(?:\\.{3})?)(?: \\[(?<year>\\d{4})\\])?(?: \\{(?<genres>.+?)\\})?(?=\\.\\S{3,4}$)",
-            "(?<title>.+?) ?(?:\\[(?<year>\\d{4})\\])? ?(?:\\{(?<genres>.+?)\\})?(?=\\.[^.]+$)"
-        ]
-    },
-    "artistGenres": {}
+    "patterns": [
+      "%ALBUMARTISTS% ≡ %ALBUM% [%YEAR%] = %TRACK% - %ARTISTS% - %TITLE%",
+      "%ARTISTS% - %ALBUM% [%YEAR%] - %TRACK% - %TITLE%",
+      "%ALBUMARTISTS% ≡ %ARTISTS% - %ALBUM% [%YEAR%] - %TITLE%",
+      "%ARTISTS% - %ALBUM% [%YEAR%] - %TITLE%",
+      "%ARTISTS% - %ALBUM% - %TRACK% - %TITLE%",
+      "%ARTISTS% - %ALBUM% - %TITLE%",
+      "%ARTISTS% - %TITLE% [%YEAR%]",
+      "%ARTISTS% - %TITLE%",
+      "%TITLE%"
+    ]
+  },
+  "duplicates": {
+    "pathSearchFor": "/Users/me/Documents/Media/",
+    "pathReplaceWith": "",
+    "savePlaylistDirectory": "/Users/me/Downloads/NewMusic",
+    "titleReplacements": [
+      " ",
+      "　",
+      "-",
+      "~",
+      "〜",
+      "/",
+      "／",
+      "?",
+      "？",
+      "!",
+      "！",
+      "AlbumVersion",
+      "AlbumVer",
+      "ShortVersion",
+      "ShortVer",
+      "()",
+      "（）",
+      "•",
+      "・",
+      ".",
+      ":",
+      "："
+    ]
+  },
+  "tagging": {
+    "regexPatterns": [
+      "(?:(?<albumArtists>.+) ≡ )?(?<album>.+?)(?: ?\\[(?<year>\\d{4})\\])? = (?<trackNo>\\d+) [–-] (?<artists>.+?) [–-] (?<title>.+)(?=\\.m4a)",
+      "(?:(?<albumArtists>.+) ≡ )?(?<album>.+?)(?: ?\\[(?<year>\\d{4})\\])? = (?<trackNo>\\d{1,3}) [–-] (?<title>.+)(?=\\.m4a)",
+      "(?:(?<albumArtists>.+) ≡ )(?<album>.+?)(?: ?\\[(?<year>\\d{4})\\])? = (?<artists>.+?) [–-] (?<title>.+)(?=\\.m4a)",
+      "(?:(?<albumArtists>.+) ≡ )?(?<album>.+?)(?: ?\\[(?<year>\\d{4})\\])? = (?<title>.+)(?=\\.m4a)",    ]
+  }
 }
 ```
 


### PR DESCRIPTION
- Allow users to specify in their settings a list of subdirectories that are excluded from renaming — i.e., the files inside those subdirectories will not be renamed
- Refactor the settings file to group renaming-related options together
- Update the `MediaFile` class to store file paths as a `FileInfo` instead of just a string, plus related refactoring
- Prefer "directory" nomenclature over "folder"