### PR TITLE
Add pluralizer utility method

### DIFF
--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -51,7 +51,8 @@ public sealed class TagDuplicateFinder : IPathOperation
             return;
         }
 
-        printer.Print($"Found {groupCount} duplicate group{(groupCount == 1 ? string.Empty : "s")} in {watch.ElapsedFriendly}.");
+        string groupLabel = Utilities.Pluralize(groupCount, "group", "groups");
+        printer.Print($"Found {groupCount} duplicate {groupLabel} in {watch.ElapsedFriendly}.");
         PrintResults(duplicateGroups, printer);
 
         string? searchFor = settings?.Duplicates?.PathSearchFor?.TextOrNull();

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -44,6 +44,13 @@ public sealed class TagDuplicateFinder : IPathOperation
             .ToImmutableArray();
 
         int groupCount = duplicateGroups.Length;
+
+        if (groupCount == 0)
+        {
+            printer.Print($"No duplicates were found after {watch.ElapsedFriendly}.");
+            return;
+        }
+
         printer.Print($"Found {groupCount} duplicate group{(groupCount == 1 ? string.Empty : "s")} in {watch.ElapsedFriendly}.");
         PrintResults(duplicateGroups, printer);
 

--- a/AudioTagger.Library/Utilities.cs
+++ b/AudioTagger.Library/Utilities.cs
@@ -19,4 +19,10 @@ public static class Utilities
             _ => "white"
         };
     }
+
+    public static string Pluralize(int count, string wordSingle, string wordZeroOrMultiple) =>
+        count switch {
+            1 => wordSingle,
+            _ => wordZeroOrMultiple
+        };
 }

--- a/AudioTagger.Library/Utilities.cs
+++ b/AudioTagger.Library/Utilities.cs
@@ -20,9 +20,9 @@ public static class Utilities
         };
     }
 
-    public static string Pluralize(int count, string wordSingle, string wordZeroOrMultiple) =>
+    public static string Pluralize(int count, string whenOne, string whenZeroOrMultiple) =>
         count switch {
-            1 => wordSingle,
-            _ => wordZeroOrMultiple
+            1 => whenOne,
+            _ => whenZeroOrMultiple
         };
 }


### PR DESCRIPTION
- Adds a `Pluralizer` utility method for conditionally providing singular and plural forms of words
- Uses the method in the duplicate-finder