### PR TITLE
Performance: Avoid overuse `List.ForEach()`

### DIFF
--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -51,13 +51,14 @@ public sealed class SpectrePrinter : IPrinter
         if (!lineParts.Any())
             return;
 
-        lineParts.ToList().ForEach(p =>
+        foreach (var linePart in lineParts)
         {
-            if (p.AddLineBreak)
-                AnsiConsole.MarkupLine(new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString());
+            var subString = new LineSubString(linePart.Text, linePart.FgColor, linePart.BgColor).GetSpectreString();
+            if (linePart.AddLineBreak)
+                AnsiConsole.MarkupLine(subString);
             else
-                AnsiConsole.Markup(new LineSubString(p.Text, p.FgColor, p.BgColor).GetSpectreString());
-        });
+                AnsiConsole.Markup(subString);
+        };
 
         PrintEmptyLines(appendLines);
     }


### PR DESCRIPTION
I've learned that `List.ForEach()` can be significantly slower than over loop types. I thought I'd review my uses and look for possible easy performance wins and code cleanup. (This is at the level of "micro-optimizations of very questionable value," admittedly.)