### PR TITLE
Cache file tag data in local JSON file

### DIFF
--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -79,9 +79,9 @@ internal static class OperationLibrary
             new TagScanner(),
             isHidden: true),
         new(
-            ["--library"],
-            "Update cached tag data to library file. (Still under development.)",
-            new TagLibraryCacher(),
+            ["--cache-tags"],
+            "Cache files' tag data locally to a JSON file whose path is specified in the settings.",
+            new TagCacher(),
             isHidden: true),
     };
 

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -80,7 +80,7 @@ internal static class OperationLibrary
             isHidden: true),
         new(
             ["--cache-tags"],
-            "Cache files' tag data locally to a JSON file whose path is specified in the settings.",
+            "Cache files' tag data locally to a JSON file whose path is specified in the settings. (Eventually, this will be helpful in speeding up certain operations.)",
             new TagCacher(),
             isHidden: true),
     };

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -78,6 +78,11 @@ internal static class OperationLibrary
             "Ad-hoc maintenance scanning work. (Not intended for normal use.)",
             new TagScanner(),
             isHidden: true),
+        new(
+            ["--library"],
+            "Update cached tag data to library file. (Still under development.)",
+            new TagLibraryCacher(),
+            isHidden: true),
     };
 
     public static Dictionary<string, string> GenerateHelpTextPairs(bool includeHidden)

--- a/AudioTagger.Console/TagCacher.cs
+++ b/AudioTagger.Console/TagCacher.cs
@@ -4,7 +4,7 @@ using System.Text.Unicode;
 
 namespace AudioTagger.Console;
 
-public sealed class TagLibraryCacher : IPathOperation
+public sealed class TagCacher : IPathOperation
 {
     private record TagSummary(
         string[] Artists,

--- a/AudioTagger.Console/TagLibraryCacher.cs
+++ b/AudioTagger.Console/TagLibraryCacher.cs
@@ -47,10 +47,11 @@ public sealed class TagLibraryCacher : IPathOperation
             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
                         System.Text.Unicode.UnicodeRanges.All)
         };
-        string json = JsonSerializer.Serialize(tagSummary, options);
+        var json = JsonSerializer.Serialize(tagSummary, options);
+        var unescapedJson = System.Text.RegularExpressions.Regex.Unescape(json);
 
         printer.Print($"Saving cached tag data to \"{settings.TagLibraryFilePath}\"...");
-        File.WriteAllText(settings.TagLibraryFilePath, json);
+        File.WriteAllText(settings.TagLibraryFilePath, unescapedJson);
         printer.Print($"Saved in {watch.ElapsedFriendly}.");
     }
 }

--- a/AudioTagger.Console/TagLibraryCacher.cs
+++ b/AudioTagger.Console/TagLibraryCacher.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Text.Encodings.Web;
+using System.Text.Unicode;
 
 namespace AudioTagger.Console;
 
@@ -28,7 +30,7 @@ public sealed class TagLibraryCacher : IPathOperation
 
         Watch watch = new();
 
-        var tagDtos = mediaFiles.Select(m => {
+        var summaries = mediaFiles.Select(m => {
                 return new TagSummary(
                     m.Artists,
                     m.Album,
@@ -44,10 +46,9 @@ public sealed class TagLibraryCacher : IPathOperation
         JsonSerializerOptions options = new()
         {
             WriteIndented = true,
-            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
-                        System.Text.Unicode.UnicodeRanges.All)
+            Encoder = JavaScriptEncoder.Create(UnicodeRanges.All)
         };
-        var json = JsonSerializer.Serialize(tagDtos, options);
+        var json = JsonSerializer.Serialize(summaries, options);
         var unescapedJson = System.Text.RegularExpressions.Regex.Unescape(json); // Avoids `\0027`, etc.
 
         printer.Print($"Saving cached tag data to \"{settings.TagLibraryFilePath}\"...");

--- a/AudioTagger.Console/TagLibraryCacher.cs
+++ b/AudioTagger.Console/TagLibraryCacher.cs
@@ -12,7 +12,7 @@ public sealed class TagLibraryCacher : IPathOperation
         uint Year,
         string[] Genres,
         TimeSpan Duration
-        // string Comment
+        // string Comment // TODO: 追加するかどうか決めよう。もしそうならば、特別な処理が必要か検討を。
     );
 
     public void Start(IReadOnlyCollection<MediaFile> mediaFiles,

--- a/AudioTagger.Console/TagLibraryCacher.cs
+++ b/AudioTagger.Console/TagLibraryCacher.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace AudioTagger.Console;
+
+public sealed class TagLibraryCacher : IPathOperation
+{
+    private record TagSummer(
+        string[] Artists,
+        string Album,
+        uint TrackNo,
+        string Title,
+        uint Year,
+        string[] Genres,
+        TimeSpan Duration
+        // string Comment
+    );
+
+    public void Start(IReadOnlyCollection<MediaFile> mediaFiles,
+                      DirectoryInfo workingDirectory,
+                      Settings settings,
+                      IPrinter printer)
+    {
+        if (settings.TagLibraryFilePath is null)
+        {
+            printer.Error("You must specify the save file path.");
+            return;
+        }
+
+        Watch watch = new();
+
+        var tagSummary = mediaFiles.Select(m => {
+                return new TagSummer(
+                    m.Artists,
+                    m.Album,
+                    m.TrackNo,
+                    m.Title,
+                    m.Year,
+                    m.Genres,
+                    m.Duration
+                );
+            });
+
+        printer.Print("Serializing the tags to JSON...");
+        JsonSerializerOptions options = new()
+        {
+            WriteIndented = true,
+            Encoder = System.Text.Encodings.Web.JavaScriptEncoder.Create(
+                        System.Text.Unicode.UnicodeRanges.All)
+        };
+        string json = JsonSerializer.Serialize(tagSummary, options);
+
+        printer.Print($"Saving cached tag data to \"{settings.TagLibraryFilePath}\"...");
+        File.WriteAllText(settings.TagLibraryFilePath, json);
+        printer.Print($"Saved in {watch.ElapsedFriendly}.");
+    }
+}

--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -18,6 +18,9 @@ public sealed record Settings
 
     [JsonPropertyName("resetSavedArtistGenres")]
     public bool ResetSavedArtistGenres { get; set; } = false;
+
+    [JsonPropertyName("tagLibraryFilePath")]
+    public string? TagLibraryFilePath { get; set; }
 }
 
 public sealed record Duplicates


### PR DESCRIPTION
What: Save a JSON file containing the text tags of all files at the specified path. Along with functioning as a data backup, this file will be used in other operations, such as duplicate searches and statistics.

Why: Reading all the tags each time can take a lot of time on some external drives. Caching the data can make some operations much faster.