### PR TITLE
Allow multiple operation flags

### DIFF
--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -103,6 +103,30 @@ internal static class OperationLibrary
             : Result.Ok(maybeOperation);
     }
 
+    public static Result<ImmutableList<IPathOperation>> GetPathOperations(IEnumerable<string> requestedOperations)
+    {
+        var successes = new List<IPathOperation>();
+        var failures = new List<string>();
+
+        Result<IPathOperation> currentResult;
+        foreach (var operation in requestedOperations)
+        {
+            currentResult = GetPathOperation(operation);
+            if (currentResult.IsSuccess)
+            {
+                successes.Add(currentResult.Value);
+            }
+            else
+            {
+                failures.Add(currentResult.Errors.First().Message);
+            }
+        }
+
+        return failures.Count == 0
+            ? Result.Ok(successes.ToImmutableList())
+            : Result.Fail(string.Join(Environment.NewLine, failures));
+    }
+
     internal sealed class Operation
     {
         public required OperationFlags Commands { get; init; }

--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -5,85 +5,85 @@ namespace AudioTagger.Console;
 
 internal static class OperationLibrary
 {
-    internal static readonly IReadOnlyList<Operation> Operations = new List<Operation>()
-    {
-        new(
-            ["-v", "--view"],
-            "View tag data.",
-            new TagViewer()
-        ),
-        new(
-            ["-vs", "--view-summary"],
-            "View a tag data summary.",
-            new TagViewerSummary()
-        ),
-        new(
-            ["-u", "--update"],
-            "Update tag data using filename patterns.",
-            new TagUpdater()
-        ),
-        new(
-            ["-u1", "--update-single"],
-            "Update a single tag in multiple files to a single, manually-specified value.",
-            new TagUpdaterSingle()
-        ),
-        new(
-            ["-ug", "--update-genres"],
-            "Update the genres in all files automatically using the artist-genre data in the settings.",
-            new TagUpdaterGenreOnly()
-        ),
-        new(
-            ["-um", "--update-multiple"],
-            "Update a single tag with multiple values for multiple files.",
-            new TagUpdaterMultiple()),
-        new(
-            ["-uy", "--update-year"],
-            "Update the year using media files' own dates of creation. (Must do before other updates, lest the creation date be modified.)",
-            new TagUpdaterYearOnly()
-        ),
-        new(
-            ["-urt", "--reverse-track-numbers"],
-            "Reverse the track numbers of the given files.",
-            new TagUpdaterReverseTrackNumbers()
-        ),
-        new(
-            ["-r", "--rename"],
-            "Rename and reorganize files into folders based on tag data.",
-            new MediaFileRenamer()
-        ),
-        new(
-            ["-d", "--duplicates"],
-            "List tracks with identical artists and titles. No files are modified or deleted.",
-            new TagDuplicateFinder()
-        ),
-        new(
-            ["-s", "--stats"],
-            "Display file statistics based on tag data.",
-            new TagStats()
-        ),
-        // new(
-        //     ["-n", "--normalize", "--replaygain"],
-        //     "Apply track normalization.",
-        //     new Normalization()),
-        new(
-            ["-g", "--genres"],
-            "Save the primary genre for each artist to a genre file.",
-            new TagGenreExtractor()),
-        new(
-            ["-p", "--parse"],
-            "Get a single tag value by parsing the data of another (generally Comments).",
-            new TagParser()),
-        new(
-            ["--scan"],
-            "Ad-hoc maintenance scanning work. (Not intended for normal use.)",
-            new TagScanner(),
-            isHidden: true),
-        new(
-            ["--cache-tags"],
-            "Cache files' tag data locally to a JSON file whose path is specified in the settings. (Eventually, this will be helpful in speeding up certain operations.)",
-            new TagCacher(),
-            isHidden: true),
-    };
+    internal static readonly IReadOnlyList<Operation> Operations =
+        [
+            new(
+                ["-v", "--view"],
+                "View tag data.",
+                new TagViewer()
+            ),
+            new(
+                ["-vs", "--view-summary"],
+                "View a tag data summary.",
+                new TagViewerSummary()
+            ),
+            new(
+                ["-u", "--update"],
+                "Update tag data using filename patterns.",
+                new TagUpdater()
+            ),
+            new(
+                ["-u1", "--update-single"],
+                "Update a single tag in multiple files to a single, manually-specified value.",
+                new TagUpdaterSingle()
+            ),
+            new(
+                ["-ug", "--update-genres"],
+                "Update the genres in all files automatically using the artist-genre data in the settings.",
+                new TagUpdaterGenreOnly()
+            ),
+            new(
+                ["-um", "--update-multiple"],
+                "Update a single tag with multiple values for multiple files.",
+                new TagUpdaterMultiple()),
+            new(
+                ["-uy", "--update-year"],
+                "Update the year using media files' own dates of creation. (Must do before other updates, lest the creation date be modified.)",
+                new TagUpdaterYearOnly()
+            ),
+            new(
+                ["-urt", "--reverse-track-numbers"],
+                "Reverse the track numbers of the given files.",
+                new TagUpdaterReverseTrackNumbers()
+            ),
+            new(
+                ["-r", "--rename"],
+                "Rename and reorganize files into folders based on tag data.",
+                new MediaFileRenamer()
+            ),
+            new(
+                ["-d", "--duplicates"],
+                "List tracks with identical artists and titles. No files are modified or deleted.",
+                new TagDuplicateFinder()
+            ),
+            new(
+                ["-s", "--stats"],
+                "Display file statistics based on tag data.",
+                new TagStats()
+            ),
+            // new(
+            //     ["-n", "--normalize", "--replaygain"],
+            //     "Apply track normalization.",
+            //     new Normalization()),
+            new(
+                ["-g", "--genres"],
+                "Save the primary genre for each artist to a genre file.",
+                new TagGenreExtractor()),
+            new(
+                ["-p", "--parse"],
+                "Get a single tag value by parsing the data of another (generally Comments).",
+                new TagParser()),
+            new(
+                ["--scan"],
+                "Ad-hoc maintenance scanning work. (Not intended for normal use.)",
+                new TagScanner(),
+                isHidden: true),
+            new(
+                ["--cache-tags"],
+                "Cache files' tag data locally to a JSON file whose path is specified in the settings. (Eventually, this will be helpful in speeding up certain operations.)",
+                new TagCacher(),
+                isHidden: true),
+        ];
 
     public static Dictionary<string, string> GenerateHelpTextPairs(bool includeHidden)
     {
@@ -108,7 +108,8 @@ internal static class OperationLibrary
             : Result.Ok(maybeOperation);
     }
 
-    public static Result<ImmutableList<IPathOperation>> GetPathOperations(IEnumerable<string> requestedOperations)
+    public static Result<ImmutableList<IPathOperation>> GetPathOperations(
+        IEnumerable<string> requestedOperations)
     {
         var successes = new List<IPathOperation>();
         var failures = new List<string>();

--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -136,7 +136,8 @@ public static class Program
         }
     }
 
-    private static (List<MediaFile>, List<string>) ReadTagsShowingProgress(ICollection<string> fileNames)
+    private static (List<MediaFile>, List<string>) ReadTagsShowingProgress(
+        ICollection<string> fileNames)
     {
         List<MediaFile> mediaFiles = new(fileNames.Count);
         List<string> tagReadErrors = [];
@@ -194,7 +195,8 @@ public static class Program
         table.AddColumns("Commands", "Descriptions");
         table.Border = TableBorder.Rounded;
 
-        foreach (KeyValuePair<string, string> pair in OperationLibrary.GenerateHelpTextPairs(includeHidden: false))
+        var helpPairs = OperationLibrary.GenerateHelpTextPairs(includeHidden: false);
+        foreach (KeyValuePair<string, string> pair in helpPairs)
         {
             table.AddRow(pair.Key, pair.Value);
         }

--- a/AudioTagger.Console/TagUpdater.cs
+++ b/AudioTagger.Console/TagUpdater.cs
@@ -33,7 +33,7 @@ public sealed class TagUpdater : IPathOperation
             }
             catch (Exception ex)
             {
-                printer.Error($"Error updating \"{mediaFile.FileNameOnly}\": {ex.Message}");
+                printer.Error($"Update error: {ex.Message}");
                 errorFiles.Add(mediaFile.FileNameOnly);
                 continue;
             }


### PR DESCRIPTION
What: Allow users to specify multiple operations at once (e.g., `-d -g`).

Why: Since scanning files can take a lot of time in some circumstances (see #73 too), allowing users to specify multiple operations at once can save considerable time, requiring only a single I/O scan for all.