### PR TITLE
Add removal of artwork from files

### DIFF
--- a/AudioTagger.Console/OperationLibrary.cs
+++ b/AudioTagger.Console/OperationLibrary.cs
@@ -47,6 +47,11 @@ internal static class OperationLibrary
                 new TagUpdaterReverseTrackNumbers()
             ),
             new(
+                ["-ura", "--remove-artwork"],
+                "Removes artwork from files. (File size is not reduced.)",
+                new TagArtworkRemover()
+            ),
+            new(
                 ["-r", "--rename"],
                 "Rename and reorganize files into folders based on tag data.",
                 new MediaFileRenamer()

--- a/AudioTagger.Console/TagArtworkRemover.cs
+++ b/AudioTagger.Console/TagArtworkRemover.cs
@@ -1,0 +1,31 @@
+namespace AudioTagger.Console;
+
+public sealed class TagArtworkRemover : IPathOperation
+{
+    public void Start(
+        IReadOnlyCollection<MediaFile> filesData,
+        DirectoryInfo workingDirectory,
+        Settings settings,
+        IPrinter printer)
+    {
+        var watch = new Watch();
+        var failures = 0;
+
+        foreach (var file in filesData)
+        {
+            try
+            {
+                file.RemoveAlbumArt();
+                file.SaveUpdates();
+            }
+            catch (Exception ex)
+            {
+                printer.Error($"Artwork removal error: {ex.Message}");
+                failures++;
+            }
+        }
+
+        var failureLabel = failures == 1 ? "failure" : "failures";
+        printer.Print($"Artwork removed in {watch.ElapsedFriendly} with {failures} {failureLabel}.");
+    }
+}

--- a/AudioTagger.Library/MediaFiles/MediaFile.cs
+++ b/AudioTagger.Library/MediaFiles/MediaFile.cs
@@ -166,11 +166,24 @@ public sealed class MediaFile
     }
 
     /// <summary>
+    /// Removes album art from the file's tag data.
+    /// </summary>
+    /// <remarks>Padding space remains, so the file size is not reduced.</remarks>
+    public void RemoveAlbumArt()
+    {
+        if (_taggedFile.Tag?.Pictures.Any() != true)
+            return;
+
+        _taggedFile.Tag.Pictures = [];
+    }
+
+    /// <summary>
     /// Save pending tag data updates to the file.
     /// </summary>
     public void SaveUpdates()
     {
         _taggedFile.Save();
+        _taggedFile.Dispose();
     }
 
     /// <summary>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A .NET CLI program that can perform the following actions on audio files:
 - Reorganize files into folders using their tag data
 - Find duplicate files by their tags
 - Auto-write genres for registered artists
-- See folder stats
+- Remove artwork
+- See media file stats
 - Apply audio normalization (ReplayGain)
 
 This is a little labor-of-love project that I work on in my spare time. It relies on the [TagLibSharp](https://github.com/mono/taglib-sharp) library for tag reading and writing.


### PR DESCRIPTION
- Add the `--remove-artwork` option to strip album artwork from files
- Use the `Discard()` method in TagLib.Sharp to correctly discard files