### PR TITLE
Add `FirstError()` methods to `Printer`

### DIFF
--- a/AudioTagger.Console/Program.cs
+++ b/AudioTagger.Console/Program.cs
@@ -31,7 +31,7 @@ public static class Program
         var readSettingsResult = SettingsService.Read(printer, createFileIfMissing: false);
         if (readSettingsResult.IsFailed)
         {
-            printer.Error(readSettingsResult.Errors[0].Message);
+            printer.FirstError(readSettingsResult);
             return;
         }
         Settings settings = readSettingsResult.Value;
@@ -92,8 +92,7 @@ public static class Program
         var fileNameResult = IOUtilities.GetAllFileNames(path, searchSubDirectories: true);
         if (fileNameResult.IsFailed)
         {
-            var firstMessage = fileNameResult.Errors.First().Message;
-            printer.Error($"Could not read any filenames for path \"{path}\": {firstMessage}");
+            printer.FirstError(fileNameResult, "Error reading filenames for path \"{path}\":");
             return;
         }
 

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -86,6 +86,18 @@ public sealed class SpectrePrinter : IPrinter
         PrintEmptyLines(appendLines);
     }
 
+    public void FirstError<T>(Result<T> result, string? prepend)
+    {
+        string pre = prepend is null ? string.Empty : $"{prepend} ";
+        Error($"{pre} {result.Errors[0].Message}");
+    }
+
+    public void FirstError(Result result, string? prepend)
+    {
+        string pre = prepend is null ? string.Empty : $"{prepend} ";
+        Error($"{pre}{result.Errors[0].Message}");
+    }
+
     public void Error(string message) =>
         Print(message, prependText: "ERROR: ", fgColor: ConsoleColor.Red);
 

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -86,10 +86,12 @@ public sealed class SpectrePrinter : IPrinter
         PrintEmptyLines(appendLines);
     }
 
-    public void FirstError(IResultBase result, string? prepend)
+    public void FirstError(IResultBase failResult, string? prepend = null)
     {
         string pre = prepend is null ? string.Empty : $"{prepend} ";
-        Error($"{pre}{result.Errors[0].Message}");
+        string message = failResult?.Errors?.FirstOrDefault()?.Message ?? string.Empty;
+
+        Error($"{pre}{message}");
     }
 
     public void Error(string message) =>

--- a/AudioTagger.Console/SpectrePrinter.cs
+++ b/AudioTagger.Console/SpectrePrinter.cs
@@ -86,13 +86,7 @@ public sealed class SpectrePrinter : IPrinter
         PrintEmptyLines(appendLines);
     }
 
-    public void FirstError<T>(Result<T> result, string? prepend)
-    {
-        string pre = prepend is null ? string.Empty : $"{prepend} ";
-        Error($"{pre} {result.Errors[0].Message}");
-    }
-
-    public void FirstError(Result result, string? prepend)
+    public void FirstError(IResultBase result, string? prepend)
     {
         string pre = prepend is null ? string.Empty : $"{prepend} ";
         Error($"{pre}{result.Errors[0].Message}");

--- a/AudioTagger.Console/TagArtworkExtractor.cs
+++ b/AudioTagger.Console/TagArtworkExtractor.cs
@@ -75,7 +75,7 @@ public sealed class TagArtworkExtractor : IPathOperation
                 else
                 {
                     failures++;
-                    printer.Error($"Artwork extraction error: {extractResult.Errors.First().Message}");
+                    printer.FirstError(extractResult, "Artwork extraction error:");
                 }
             }
 
@@ -92,14 +92,14 @@ public sealed class TagArtworkExtractor : IPathOperation
                 var saveResult = file.SaveUpdates();
                 if (saveResult.IsFailed)
                 {
-                    printer.Error(saveResult.Errors.First().Message);
+                    printer.FirstError(saveResult);
                     continue;
                 }
 
                 var rewriteResult = file.RewriteFileTags();
                 if (rewriteResult.IsFailed)
                 {
-                    printer.Error(rewriteResult.Errors.First().Message);
+                    printer.FirstError(rewriteResult);
                     continue;
                 }
 

--- a/AudioTagger.Console/TagGenreExtractor.cs
+++ b/AudioTagger.Console/TagGenreExtractor.cs
@@ -90,7 +90,7 @@ public sealed class TagGenreExtractor : IPathOperation
         if (writeResult.IsSuccess)
             printer.Success($"Genres written to \"{settings.ArtistGenreCsvFilePath}\" in {watch.ElapsedFriendly}.");
         else
-            printer.Error(writeResult.Errors.First().Message);
+            printer.FirstError(writeResult, "Genre save error: ");
 
         static void WriteSummary(int beforeCount, int afterCount, IPrinter printer)
         {

--- a/AudioTagger.Console/TagRewriter.cs
+++ b/AudioTagger.Console/TagRewriter.cs
@@ -17,7 +17,7 @@ public sealed class TagRewriter : IPathOperation
             result = file.RewriteFileTags();
             if (result.IsFailed)
             {
-                printer.Error(result.Errors.First().Message);
+                printer.FirstError(result);
             }
         }
 

--- a/AudioTagger.Console/TagUpdaterGenreOnly.cs
+++ b/AudioTagger.Console/TagUpdaterGenreOnly.cs
@@ -18,7 +18,7 @@ public sealed class TagUpdaterGenreOnly : IPathOperation
         var readResult = GenreService.Read(settings.ArtistGenreCsvFilePath);
         if (readResult.IsFailed)
         {
-            printer.Error(readResult.Errors.First().Message);
+            printer.FirstError(readResult, "Genre read error:");
             return;
         }
 

--- a/AudioTagger.Library/Genres/GenreService.cs
+++ b/AudioTagger.Library/Genres/GenreService.cs
@@ -61,7 +61,7 @@ public static class GenreService
         }
         catch (Exception ex)
         {
-            return Result.Fail($"Reading the genre file failed: {ex.Message}");
+            return Result.Fail(ex.Message);
         }
     }
 

--- a/AudioTagger.Library/IPrinter.cs
+++ b/AudioTagger.Library/IPrinter.cs
@@ -16,7 +16,7 @@ public interface IPrinter
 
     void Error(string message);
 
-    void FirstError(IResultBase result, string? prepend = null);
+    void FirstError(IResultBase failResult, string? prepend = null);
 
     void Warning(string message);
 

--- a/AudioTagger.Library/IPrinter.cs
+++ b/AudioTagger.Library/IPrinter.cs
@@ -16,9 +16,7 @@ public interface IPrinter
 
     void Error(string message);
 
-    void FirstError<T>(Result<T> result, string? prepend = null);
-
-    void FirstError(Result result, string? prepend = null);
+    void FirstError(IResultBase result, string? prepend = null);
 
     void Warning(string message);
 

--- a/AudioTagger.Library/IPrinter.cs
+++ b/AudioTagger.Library/IPrinter.cs
@@ -1,4 +1,5 @@
 ﻿using AudioTagger.Library.MediaFiles;
+using FluentResults;
 
 namespace AudioTagger;
 
@@ -14,6 +15,10 @@ public interface IPrinter
     void Print(string message, ResultType type, byte prependLines = 0, byte appendLines = 0);
 
     void Error(string message);
+
+    void FirstError<T>(Result<T> result, string? prepend = null);
+
+    void FirstError(Result result, string? prepend = null);
 
     void Warning(string message);
 


### PR DESCRIPTION
I just got tired of repeatedly writing `result.Errors.First().Message`... ^_^

So, this added a new static `Printer` method that accepts a `Result` and prints the first error message.