### PR TITLE
Add case-insensitivity and artist replacements to duplicate detection

### DIFF
--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -66,8 +66,6 @@ public sealed class TagDuplicateFinder : IPathOperation
             settings?.Duplicates?.SavePlaylistDirectory,
             (searchFor, replaceWith),
             printer);
-
-        return;
     }
 
     /// <summary>

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -33,14 +33,15 @@ public sealed class TagDuplicateFinder : IPathOperation
             printer.Print($"Out of {mediaFiles.Count:#,##0} media files, {diff:#,##0} {wasWere} excluded via exclusion rules.");
         }
 
+        static string pluralizeTerm(int count) => Utilities.Pluralize(count, "term", "terms");
+
         var artistReplacements =  settings.Duplicates?.ArtistReplacements ?? [];
-        string artistLabel = Utilities.Pluralize(artistReplacements.Count, "term", "terms");
+        string artistLabel = pluralizeTerm(artistReplacements.Count);
         printer.Print($"Found {artistReplacements.Count} artist replacement {artistLabel}.");
 
         var titleReplacements = settings.Duplicates?.TitleReplacements ?? [];
-        string titleLabel = Utilities.Pluralize(titleReplacements.Count, "term", "terms");
+        string titleLabel = pluralizeTerm(titleReplacements.Count);
         printer.Print($"Found {titleReplacements.Count} title replacement {titleLabel}.");
-
 
         var duplicateGroups = includedFiles
             .ToLookup(m =>

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -63,11 +63,8 @@ public sealed class TagDuplicateFinder : IPathOperation
 
         string? searchFor = settings?.Duplicates?.PathSearchFor?.TextOrNull();
         string? replaceWith = settings?.Duplicates?.PathReplaceWith?.TextOrNull();
-        CreatePlaylistFile(
-            duplicateGroups,
-            settings?.Duplicates?.SavePlaylistDirectory,
-            (searchFor, replaceWith),
-            printer);
+        string? saveDir = settings?.Duplicates?.SavePlaylistDirectory;
+        CreatePlaylistFile(duplicateGroups, saveDir, (searchFor, replaceWith), printer);
     }
 
     /// <summary>

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -33,18 +33,20 @@ public sealed class TagDuplicateFinder : IPathOperation
             printer.Print($"Out of {mediaFiles.Count:#,##0} media files, {diff:#,##0} {wasWere} excluded via exclusion rules.");
         }
 
-        var titleReplacements = settings.Duplicates?.TitleReplacements ?? [];
-        printer.Print($"Found {titleReplacements.Count} title replacement term(s).");
-
         var artistReplacements =  settings.Duplicates?.ArtistReplacements ?? [];
-        printer.Print($"Found {artistReplacements.Count} artist replacement term(s).");
+        string artistLabel = Utilities.Pluralize(artistReplacements.Count, "term", "terms");
+        printer.Print($"Found {artistReplacements.Count} artist replacement {artistLabel}.");
+
+        var titleReplacements = settings.Duplicates?.TitleReplacements ?? [];
+        string titleLabel = Utilities.Pluralize(titleReplacements.Count, "term", "terms");
+        printer.Print($"Found {titleReplacements.Count} title replacement {titleLabel}.");
+
 
         var duplicateGroups = includedFiles
             .ToLookup(m =>
                 RemoveSubstrings(m.ArtistSummary, artistReplacements) +
                 RemoveSubstrings(m.Title, titleReplacements),
-                StringComparer.OrdinalIgnoreCase
-            )
+                StringComparer.OrdinalIgnoreCase)
             .Where(g => g.Key.HasText() && g.Count() > 1)
             .OrderBy(g => g.Key)
             .ToImmutableArray();
@@ -150,8 +152,8 @@ public sealed class TagDuplicateFinder : IPathOperation
     }
 
     /// <summary>
-    /// Removes occurrences of each of a collection of substrings from a string.
-    /// Returns the source string as-is if no replacement terms were passed in.
+    /// Removes each of collection of substrings from a source string.
+    /// Returns the source as-is if no replacement terms are provided.
     /// </summary>
     private static string RemoveSubstrings(string source, ICollection<string> terms)
     {

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -36,7 +36,9 @@ public sealed class TagDuplicateFinder : IPathOperation
         var titleReplacements = settings.Duplicates?.TitleReplacements ?? [];
         printer.Print($"Found {titleReplacements.Count} title replacement term(s).");
 
-        var artistReplacements =  new string[] { "The ", "ザ・" }; // TODO: Make a new setting.
+        var artistReplacements =  settings.Duplicates?.ArtistReplacements ?? [];
+        printer.Print($"Found {artistReplacements.Count} artist replacement term(s).");
+
         var duplicateGroups = includedFiles
             .ToLookup(m =>
                 RemoveSubstrings(m.ArtistSummary, artistReplacements) +

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -73,7 +73,7 @@ public sealed class TagDuplicateFinder : IPathOperation
     /// manually specified in the user's settings file.
     /// </summary>
     /// <returns>Returns `true` if the file should be excluded; otherwise, `false`.</returns>
-    private static bool ExcludeFile(MediaFile file, ImmutableList<ExclusionPair> exclusions)
+    private static bool ExcludeFile(MediaFile file, ICollection<ExclusionPair> exclusions)
     {
         return exclusions.Any(exclusion =>
         {
@@ -94,7 +94,7 @@ public sealed class TagDuplicateFinder : IPathOperation
     }
 
     private static void PrintResults(
-        IList<IGrouping<string, MediaFile>> duplicateGroups,
+        ICollection<IGrouping<string, MediaFile>> duplicateGroups,
         IPrinter printer)
     {
         int groupIndex = 1;
@@ -173,7 +173,7 @@ public sealed class TagDuplicateFinder : IPathOperation
     /// <param name="replacements">Optionally replace parts of the file paths.</param>
     /// <param name="printer"></param>
     private static void CreatePlaylistFile(
-        ImmutableArray<IGrouping<string, MediaFile>> duplicateGroups,
+        ICollection<IGrouping<string, MediaFile>> duplicateGroups,
         string? saveDirectory,
         (string? SearchFor, string? ReplaceWith) replacements,
         IPrinter printer)

--- a/AudioTagger.Console/TagDuplicateFinder.cs
+++ b/AudioTagger.Console/TagDuplicateFinder.cs
@@ -38,7 +38,8 @@ public sealed class TagDuplicateFinder : IPathOperation
 
         var duplicateGroups = includedFiles
             .ToLookup(m => ConcatenateCollectionText(m.Artists) +
-                           RemoveSubstrings(m.Title, titleReplacements))
+                           RemoveSubstrings(m.Title, titleReplacements),
+                           StringComparer.OrdinalIgnoreCase)
             .Where(m => m.Key.HasText() && m.Count() > 1)
             .OrderBy(m => m.Key)
             .ToImmutableArray();

--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -28,6 +28,9 @@ public sealed record Duplicates
     [JsonPropertyName("titleReplacements")]
     public ImmutableList<string>? TitleReplacements { get; set; }
 
+    [JsonPropertyName("artistReplacements")]
+    public ImmutableList<string>? ArtistReplacements { get; set; }
+
     [JsonPropertyName("pathSearchFor")]
     public string? PathSearchFor { get; set; }
 

--- a/AudioTagger.Library/Settings/Settings.cs
+++ b/AudioTagger.Library/Settings/Settings.cs
@@ -23,27 +23,59 @@ public sealed record Settings
     public string? TagCacheFilePath { get; set; }
 }
 
+/// <summary>
+/// Settings related to finding duplicate tracks via their tag data.
+/// </summary>
 public sealed record Duplicates
 {
+    /// <summary>
+    /// A collection of substrings that should be ignored when searching for
+    /// duplicate artist names. For example, if "The " is added, then
+    /// "The Beatles" and "Beatles" would be recognized as the same artist.
+    /// </summary>
     [JsonPropertyName("titleReplacements")]
     public ImmutableList<string>? TitleReplacements { get; set; }
 
+    /// <summary>
+    /// A collection of substrings that should be ignored when searching for
+    /// duplicate track titles. For example, if "(Remix)" is added, then
+    /// "TrackTitle" and "TrackTitle (Remix)" would be considered identical.
+    /// </summary>
     [JsonPropertyName("artistReplacements")]
     public ImmutableList<string>? ArtistReplacements { get; set; }
 
+    /// <summary>
+    /// When creating a playlist file, search for this substring in
+    /// the duplicate files' paths (with the intention of replacing it
+    /// with the string specified in the `PathReplaceWith` property).
+    /// </summary>
     [JsonPropertyName("pathSearchFor")]
     public string? PathSearchFor { get; set; }
 
+    /// <summary>
+    /// When creating a playlist of duplicate tracks, replace the matched
+    /// path substring from the `PathSearchFor` property with this text.
+    /// </summary>
     [JsonPropertyName("pathReplaceWith")]
     public string? PathReplaceWith { get; set; }
 
+    /// <summary>
+    /// The directory to which the playlist of duplicates should be saved.
+    /// </summary>
     [JsonPropertyName("savePlaylistDirectory")]
     public string? SavePlaylistDirectory { get; set; }
 
+    /// <summary>
+    /// Track metadata that should be ignored when searching for duplicates.
+    /// </summary>
     [JsonPropertyName("exclusions")]
     public ImmutableList<ExclusionPair>? Exclusions { get; set; }
 }
 
+/// <summary>
+/// An artist, track title, or combinations of both that should be ignored
+/// when searching for duplicate tracks.
+/// </summary>
 public sealed record ExclusionPair
 {
     [JsonPropertyName("artist")]


### PR DESCRIPTION
- Adds case-insensitivity to the duplicate finder
- Add `artistReplacements` setting (for temporarily modifying artist names for duplicate checking)
- Minor: Use more `ICollection`s in method signatures
- Minor: Other class cleanup