### PR TITLE
Improve duplicate search artist filtering

### DIFF
--- a/src/AudioTagger.Console/Operations/TagDuplicateFinder.cs
+++ b/src/AudioTagger.Console/Operations/TagDuplicateFinder.cs
@@ -45,7 +45,7 @@ public sealed class TagDuplicateFinder : IPathOperation
 
         var duplicateGroups = includedFiles
             .ToLookup(m =>
-                RemoveSubstrings(m.ArtistSummary, artistReplacements) +
+                RemoveSubstrings(m.Artists.FirstOrDefault() ?? string.Empty, artistReplacements) +
                 RemoveSubstrings(m.Title, titleReplacements),
                 StringComparer.OrdinalIgnoreCase)
             .Where(g => g.Key.HasText() && g.Count() > 1)
@@ -164,7 +164,7 @@ public sealed class TagDuplicateFinder : IPathOperation
             _ => terms.Aggregate(
                     new StringBuilder(source),
                     (sb, term) => sb.Replace(term, string.Empty),
-                    sb => sb.ToString())
+                    sb => sb.ToString().Trim())
         };
     }
 


### PR DESCRIPTION
The artist filtering of duplicate file searches wasn't working well, so I improved it. (I found a lot of duplicates in my personal collection that had heretofore been undiscovered. Nice.)