### PR TITLE
Normalize renamed files' names

### DIFF
--- a/src/.idea/.idea.AudioTagger/.idea/.gitignore
+++ b/src/.idea/.idea.AudioTagger/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/.idea.AudioTagger.iml
+/modules.xml
+/projectSettingsUpdater.xml
+/contentModel.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/src/.idea/.idea.AudioTagger/.idea/.name
+++ b/src/.idea/.idea.AudioTagger/.idea/.name
@@ -1,0 +1,1 @@
+AudioTagger

--- a/src/.idea/.idea.AudioTagger/.idea/indexLayout.xml
+++ b/src/.idea/.idea.AudioTagger/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/src/.idea/.idea.AudioTagger/.idea/vcs.xml
+++ b/src/.idea/.idea.AudioTagger/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
+++ b/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
@@ -215,7 +215,8 @@ public sealed class MediaFileRenamer : IPathOperation
         string newAlbumDir = useAlbumDirectory && useArtistDirectory && file.Album.HasText()
             ? IoUtilities.SanitizePath(file.Album)
             : string.Empty;
-        string newFileName = GenerateFileName(file, populatedTagNames, matchedRenamePattern).Normalize();
+        string newFileName = GenerateFileName(file, populatedTagNames, matchedRenamePattern)
+                                .Normalize(NormalizationForm.FormC);
         var newPathInfo = new MediaFilePathInfo(workingPath, [newArtistDir, newAlbumDir], newFileName);
 
         if (oldPathInfo.FullFilePath(true) == newPathInfo.FullFilePath(true))

--- a/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
+++ b/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
@@ -67,7 +67,7 @@ public sealed class MediaFileRenamer : IPathOperation
             "KC" => NormalizationForm.FormKC,
             _ => NormalizationForm.FormC
         };
-        printer.Print($"Normalization form is {normalizationForm}.");
+        printer.Print($"Filename normalization form is {normalizationForm}.");
 
         RenameFiles(
             eligibleMediaFiles,
@@ -117,7 +117,7 @@ public sealed class MediaFileRenamer : IPathOperation
 
         for (int i = 0; i < mediaFiles.Count; i++)
         {
-            MediaFile file = mediaFiles.ElementAt(i);
+            var file = mediaFiles.ElementAt(i);
 
             if (file.Title.Length == 0)
             {

--- a/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
+++ b/src/AudioTagger.Console/Operations/MediaFileRenamer.cs
@@ -207,7 +207,7 @@ public sealed class MediaFileRenamer : IPathOperation
             return false;
         }
 
-        MediaFilePathInfo oldPathInfo = new(workingPath, file.FileInfo.FullName);
+        var oldPathInfo = new MediaFilePathInfo(workingPath, file.FileInfo.FullName);
 
         string newArtistDir = useArtistDirectory
             ? GenerateSafeDirectoryName(file)
@@ -215,8 +215,8 @@ public sealed class MediaFileRenamer : IPathOperation
         string newAlbumDir = useAlbumDirectory && useArtistDirectory && file.Album.HasText()
             ? IoUtilities.SanitizePath(file.Album)
             : string.Empty;
-        string newFileName = GenerateFileNameUsingPattern(file, populatedTagNames, matchedRenamePattern);
-        MediaFilePathInfo newPathInfo = new(workingPath, [newArtistDir, newAlbumDir], newFileName);
+        string newFileName = GenerateFileName(file, populatedTagNames, matchedRenamePattern).Normalize();
+        var newPathInfo = new MediaFilePathInfo(workingPath, [newArtistDir, newAlbumDir], newFileName);
 
         if (oldPathInfo.FullFilePath(true) == newPathInfo.FullFilePath(true))
         {
@@ -271,7 +271,7 @@ public sealed class MediaFileRenamer : IPathOperation
         /// Generates and returns a new filename by replacing placeholders within the rename
         /// pattern (e.g., `%ALBUM%`) with actual tag data from the `MediaFile`.
         /// </summary>
-        static string GenerateFileNameUsingPattern(
+        static string GenerateFileName(
             MediaFile file,
             ICollection<string> fileTagNames,
             string renamePattern)

--- a/src/AudioTagger.Library/UserSettings/Settings.cs
+++ b/src/AudioTagger.Library/UserSettings/Settings.cs
@@ -99,6 +99,14 @@ public sealed record Renaming
     [JsonPropertyName("useAlbumDirectories")]
     public bool UseAlbumDirectories { get; init; } = false;
 
+    /// <summary>
+    /// The Unicode normalization form to use for renamed filenames.
+    /// Valid values are `C`, `D`, `KC`, and `KD`.
+    /// `C` is used by default is no valid value is provided.
+    ///
+    /// Reference: https://unicode.org/reports/tr15/
+    /// Reference: https://en.wikipedia.org/wiki/Unicode_equivalence
+    /// </summary>
     [JsonPropertyName("normalizationForm")]
     public string NormalizationForm { get; init; } = "C";
 

--- a/src/AudioTagger.Library/UserSettings/Settings.cs
+++ b/src/AudioTagger.Library/UserSettings/Settings.cs
@@ -99,6 +99,9 @@ public sealed record Renaming
     [JsonPropertyName("useAlbumDirectories")]
     public bool UseAlbumDirectories { get; init; } = false;
 
+    [JsonPropertyName("normalizationForm")]
+    public string NormalizationForm { get; init; } = "C";
+
     [JsonPropertyName("ignoredDirectories")]
     public ImmutableList<string>? IgnoredDirectories { get; init; }
 }


### PR DESCRIPTION
- Add a rename setting to specify the Unicode normalization form to use for renamed files, defaulting to NFC
    - This is somewhat related to [my recent blog post on the topic](https://codeconscious.github.io/2025/02/01/recursive-path-normalizer.html)
- Minor style tweaks
- Remove some JetBrains Rider files from the repo